### PR TITLE
docs: document entity ordering strategies in repositories

### DIFF
--- a/src/resumes/repositories/education.repository.ts
+++ b/src/resumes/repositories/education.repository.ts
@@ -4,6 +4,14 @@ import { Education } from '@prisma/client';
 import { CreateEducationDto, UpdateEducationDto } from '../dto/education.dto';
 import { PaginatedResult } from '../dto/pagination.dto';
 
+/**
+ * Ordering strategy: by startDate DESC (most recent first)
+ *
+ * Rationale: Education entries are naturally chronological - most recent degrees
+ * should appear first. Unlike experiences, education ordering is date-driven
+ * rather than user-defined. Note: order field exists for future manual reordering
+ * capability but is not currently used in findAll queries.
+ */
 @Injectable()
 export class EducationRepository {
   private readonly logger = new Logger(EducationRepository.name);

--- a/src/resumes/repositories/experience.repository.ts
+++ b/src/resumes/repositories/experience.repository.ts
@@ -7,6 +7,13 @@ import {
 } from '../dto/experience.dto';
 import { PaginatedResult } from '../dto/pagination.dto';
 
+/**
+ * Ordering strategy: by user-defined order field (asc)
+ *
+ * Rationale: Experiences should be ordered as the user prefers,
+ * typically most recent first but allowing manual reordering via drag-and-drop.
+ * The order field provides explicit control over display sequence.
+ */
 @Injectable()
 export class ExperienceRepository {
   private readonly logger = new Logger(ExperienceRepository.name);

--- a/src/resumes/repositories/language.repository.ts
+++ b/src/resumes/repositories/language.repository.ts
@@ -4,6 +4,13 @@ import { Language } from '@prisma/client';
 import { CreateLanguageDto, UpdateLanguageDto } from '../dto/language.dto';
 import { PaginatedResult } from '../dto/pagination.dto';
 
+/**
+ * Ordering strategy: by user-defined order field (asc)
+ *
+ * Rationale: Languages should be ordered by proficiency or preference as the user decides.
+ * Unlike date-based entities, there is no natural chronological order for languages,
+ * so explicit user control via the order field is the most appropriate strategy.
+ */
 @Injectable()
 export class LanguageRepository {
   private readonly logger = new Logger(LanguageRepository.name);

--- a/src/resumes/repositories/skill.repository.ts
+++ b/src/resumes/repositories/skill.repository.ts
@@ -4,6 +4,14 @@ import { Skill } from '@prisma/client';
 import { CreateSkillDto, UpdateSkillDto } from '../dto/skill.dto';
 import { PaginatedResult } from '../dto/pagination.dto';
 
+/**
+ * Ordering strategy: by category ASC, then order ASC (grouped by category, user-defined within group)
+ *
+ * Rationale: Skills are logically grouped by category (e.g., "Frontend", "Backend", "DevOps").
+ * Primary sort by category keeps related skills together. Secondary sort by order field
+ * allows manual reordering within each category via drag-and-drop. This two-level hierarchy
+ * provides both logical grouping and user control.
+ */
 @Injectable()
 export class SkillRepository {
   private readonly logger = new Logger(SkillRepository.name);


### PR DESCRIPTION
## Summary

Adds comprehensive documentation explaining ordering logic for each repository:
- **Experience**: user-defined order field (manual reordering via drag-and-drop)
- **Education**: startDate DESC (chronological, most recent first) - *Note: order field exists but not used in queries*
- **Skill**: category ASC + order ASC (grouped by category with manual reordering within groups)
- **Language**: user-defined order field (preference-based)

## Changes

- Added JSDoc comments to ExperienceRepository explaining order field strategy
- Added JSDoc comments to EducationRepository explaining startDate DESC strategy and noting unused order field
- Added JSDoc comments to SkillRepository explaining two-level ordering (category + order)
- Added JSDoc comments to LanguageRepository explaining user-defined order strategy

## Test plan

- [x] All existing tests pass
- [x] No functional changes, documentation only
- [x] Comments clearly explain rationale for each ordering strategy

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)