### PR TITLE
fix(api): close UI sync gaps (WEEKLY mode, shadow claim, ATS simulate)

### DIFF
--- a/.attestation
+++ b/.attestation
@@ -1,38 +1,38 @@
 {
   "version": "3",
-  "tree_hash": "c49472b710224789b88a6fc8ce48849bbdee4a9f",
+  "tree_hash": "528c5ab2d14cfe9ca2b233327ce169d156f9b54e",
   "checks": "swagger typecheck lint unit arch contract",
   "metrics": {
     "typecheck": {
       "status": "ok",
-      "time_ms": 4447
+      "time_ms": 4431
     },
     "lint": {
       "status": "ok",
-      "time_ms": 1490
+      "time_ms": 1215
     },
     "unit": {
       "status": "ok",
-      "time_ms": 6417,
+      "time_ms": 6201,
       "passed": 2876,
       "failed": 0,
       "skipped": 0
     },
     "arch": {
       "status": "ok",
-      "time_ms": 1781,
+      "time_ms": 1436,
       "passed": 42,
       "failed": 0,
       "skipped": 1
     },
     "contract": {
       "status": "ok",
-      "time_ms": 796,
+      "time_ms": 615,
       "passed": 42,
       "failed": 0,
       "skipped": 0
     }
   },
-  "timestamp": "2026-04-19T18:43:49Z",
+  "timestamp": "2026-04-19T22:26:16Z",
   "git_user": "enzo.patti@aluno.senai.br"
 }

--- a/client-swagger.json
+++ b/client-swagger.json
@@ -8246,7 +8246,40 @@
             "bearer": []
           }
         ],
-        "summary": "Run a resume AST through the ATS parser simulator and return the extracted text + warnings.",
+        "summary": "Run an explicit AtsSimulationInput payload through the simulator. Use this when the caller has already shaped the AST.",
+        "tags": ["ats"]
+      }
+    },
+    "/api/v1/ats/simulate/{resumeId}": {
+      "get": {
+        "operationId": "ats_simulateForResume",
+        "parameters": [
+          {
+            "name": "resumeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Requires permission: resume:read"
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Convenience endpoint: load a resume by id, map it to AtsSimulationInput, and run the simulator in one call.",
         "tags": ["ats"]
       }
     },

--- a/prisma/migrations/20260419221438_email_delivery_weekly/migration.sql
+++ b/prisma/migrations/20260419221438_email_delivery_weekly/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "EmailDeliveryMode" ADD VALUE 'WEEKLY';

--- a/prisma/schema/notification.prisma
+++ b/prisma/schema/notification.prisma
@@ -46,6 +46,7 @@ model NotificationPreference {
 enum EmailDeliveryMode {
   INSTANT
   DAILY
+  WEEKLY
   OFF
 }
 

--- a/src/bounded-contexts/ats-validation/ats/ats.module.ts
+++ b/src/bounded-contexts/ats-validation/ats/ats.module.ts
@@ -22,6 +22,7 @@ import {
 } from './scoring';
 import { ATSService } from './services/ats.service';
 import { ATSSectionTypeAdapter } from './services/ats-section-type.adapter';
+import { AtsSimulatorService } from './services/ats-simulator.service';
 import { EncodingNormalizerService } from './services/encoding-normalizer.service';
 import { SectionSemanticCatalogAdapter } from './services/section-semantic-catalog.adapter';
 import { TextExtractionService } from './services/text-extraction.service';
@@ -40,6 +41,7 @@ import { SectionOrderValidator } from './validators/section-order.validator';
     // ATS Definition-driven adapter
     ATSSectionTypeAdapter,
     ATSService,
+    AtsSimulatorService,
     TextExtractionService,
     EncodingNormalizerService,
     CVSectionParser,

--- a/src/bounded-contexts/ats-validation/ats/services/ats-simulator.service.ts
+++ b/src/bounded-contexts/ats-validation/ats/services/ats-simulator.service.ts
@@ -1,0 +1,61 @@
+/**
+ * ATS Simulator Service
+ *
+ * Loads a resume from Prisma, maps it to the simulator input shape, and
+ * runs the parser simulation. Lives as a service (not in the controller)
+ * so the architectural rule banning DB queries in controllers stays clean.
+ */
+
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/bounded-contexts/platform/prisma/prisma.service';
+import {
+  EntityNotFoundException,
+  ForbiddenException,
+} from '@/shared-kernel/exceptions/domain.exceptions';
+import { type AtsSimulationResult, simulateAtsParsing } from '../simulation/ats-parser-simulator';
+import { buildSimulationInput } from '../simulation/build-simulation-input';
+
+@Injectable()
+export class AtsSimulatorService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async simulateForResume(resumeId: string, viewerId: string): Promise<AtsSimulationResult> {
+    const resume = await this.prisma.resume.findUnique({
+      where: { id: resumeId },
+      select: {
+        userId: true,
+        resumeSections: {
+          where: { isVisible: true },
+          orderBy: { order: 'asc' },
+          select: {
+            titleOverride: true,
+            sectionType: { select: { title: true, semanticKind: true } },
+            items: {
+              where: { isVisible: true },
+              orderBy: { order: 'asc' },
+              select: { content: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!resume) throw new EntityNotFoundException('Resume', resumeId);
+    if (resume.userId !== viewerId) {
+      throw new ForbiddenException('You do not have access to this resume');
+    }
+
+    const input = buildSimulationInput({
+      sections: resume.resumeSections.map((s) => ({
+        title: s.titleOverride ?? s.sectionType.title,
+        semanticKind: s.sectionType.semanticKind,
+        column: 'full-width',
+        items: s.items.map((it) => ({
+          content: (it.content as Record<string, unknown> | null) ?? null,
+        })),
+      })),
+    });
+
+    return simulateAtsParsing(input);
+  }
+}

--- a/src/bounded-contexts/ats-validation/ats/simulation/build-simulation-input.ts
+++ b/src/bounded-contexts/ats-validation/ats/simulation/build-simulation-input.ts
@@ -1,0 +1,56 @@
+/**
+ * Adapter that maps Prisma resume rows to the AtsSimulationInput shape the
+ * parser simulator expects. Lives in the ATS context (not in resumes/) so
+ * the resumes module doesn't need to know about ATS internals.
+ */
+
+import type { AtsSimulationInput } from './ats-parser-simulator';
+
+export interface ResumeForSimulation {
+  layout?: { type?: string | null } | null;
+  sections: Array<{
+    title: string | null;
+    semanticKind: string;
+    column?: string | null;
+    items: Array<{
+      content: Record<string, unknown> | null;
+    }>;
+  }>;
+}
+
+function flattenContentToFields(content: Record<string, unknown> | null): Record<string, string> {
+  if (!content) return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(content)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'string') {
+      out[key] = value;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      out[key] = String(value);
+    } else if (Array.isArray(value)) {
+      out[key] = value.filter((v) => typeof v === 'string').join(', ');
+    }
+    // Nested objects are intentionally ignored — ATS parsers see flat text.
+  }
+  return out;
+}
+
+function normaliseColumn(raw: string | null | undefined): 'main' | 'sidebar' | 'full-width' {
+  if (raw === 'sidebar') return 'sidebar';
+  if (raw === 'main') return 'main';
+  return 'full-width';
+}
+
+export function buildSimulationInput(resume: ResumeForSimulation): AtsSimulationInput {
+  const layoutType = resume.layout?.type === 'two-column' ? 'two-column' : 'single-column';
+
+  return {
+    layout: { type: layoutType },
+    sections: resume.sections.map((s) => ({
+      title: s.title ?? '',
+      semanticKind: s.semanticKind,
+      column: normaliseColumn(s.column),
+      items: s.items.map((it) => ({ fields: flattenContentToFields(it.content) })),
+    })),
+  };
+}

--- a/src/bounded-contexts/ats-validation/infrastructure/controllers/ats-simulator.controller.ts
+++ b/src/bounded-contexts/ats-validation/infrastructure/controllers/ats-simulator.controller.ts
@@ -1,11 +1,13 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { UserPayload } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
 import { CurrentUser } from '@/bounded-contexts/platform/common/decorators/current-user.decorator';
 import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
 import { Permission, RequirePermission } from '@/shared-kernel/authorization';
+import { AtsSimulatorService } from '../../ats/services/ats-simulator.service';
 import {
   type AtsSimulationInput,
+  type AtsSimulationResult,
   simulateAtsParsing,
 } from '../../ats/simulation/ats-parser-simulator';
 
@@ -14,18 +16,34 @@ import {
 @ApiBearerAuth('JWT-auth')
 @Controller('v1/ats/simulate')
 export class AtsSimulatorController {
+  constructor(private readonly service: AtsSimulatorService) {}
+
   @Post()
   @RequirePermission(Permission.RESUME_READ)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary:
-      'Run a resume AST through the ATS parser simulator and return the extracted text + warnings.',
+      'Run an explicit AtsSimulationInput payload through the simulator. Use this when the caller has already shaped the AST.',
   })
   async simulate(
     @CurrentUser() _user: UserPayload,
     @Body() body: AtsSimulationInput,
-  ): Promise<{ success: true; data: ReturnType<typeof simulateAtsParsing> }> {
-    const result = simulateAtsParsing(body);
-    return { success: true, data: result };
+  ): Promise<{ success: true; data: AtsSimulationResult }> {
+    return { success: true, data: simulateAtsParsing(body) };
+  }
+
+  @Get(':resumeId')
+  @RequirePermission(Permission.RESUME_READ)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Convenience endpoint: load a resume by id, map it to AtsSimulationInput, and run the simulator in one call.',
+  })
+  async simulateForResume(
+    @CurrentUser() user: UserPayload,
+    @Param('resumeId') resumeId: string,
+  ): Promise<{ success: true; data: AtsSimulationResult }> {
+    const data = await this.service.simulateForResume(resumeId, user.userId);
+    return { success: true, data };
   }
 }

--- a/src/bounded-contexts/identity/oauth/controllers/oauth.controller.ts
+++ b/src/bounded-contexts/identity/oauth/controllers/oauth.controller.ts
@@ -96,8 +96,21 @@ export class OAuthController {
     // the userId + marker and calls our create-session endpoint (which sets
     // the httpOnly cookie). Keeping this controller session-agnostic avoids
     // duplicating the JWT/cookie logic that already lives in Authentication.
+    //
+    // We also forward the verified email and (for github) the external
+    // username so the UI can immediately probe for a pre-built shadow
+    // profile and offer to claim it.
     const base = this.config.get<string>('UI_BASE_URL') ?? '';
-    const target = `${base}/auth/oauth-complete?provider=${provider}&userId=${userId}&created=${created}`;
-    res.redirect(target);
+    const params = new URLSearchParams({
+      provider,
+      userId,
+      created: String(created),
+    });
+    if (req.user.email) params.set('email', req.user.email);
+    const externalLogin = (req.user.raw as { login?: unknown } | null)?.login;
+    if (provider === 'github' && typeof externalLogin === 'string') {
+      params.set('githubLogin', externalLogin);
+    }
+    res.redirect(`${base}/auth/oauth-complete?${params.toString()}`);
   }
 }

--- a/src/bounded-contexts/identity/users/shadow-profile/shadow-profile.service.ts
+++ b/src/bounded-contexts/identity/users/shadow-profile/shadow-profile.service.ts
@@ -87,6 +87,11 @@ export class ShadowProfileService {
       throw new ConflictException('Shadow profile already claimed by another user');
     }
 
+    // Apply the shadow payload to the user's primary resume so the claim is
+    // user-visible. Creates a fresh resume if there isn't one yet, otherwise
+    // merges (existing skills win on conflict — never overwrite curated data).
+    await this.applyPayloadToUser(userId, existing.payload as PayloadShape);
+
     const claimed = await this.prisma.shadowProfile.update({
       where: { id: shadowId },
       data: { claimedByUserId: userId, claimedAt: new Date() },
@@ -101,4 +106,53 @@ export class ShadowProfileService {
       claimedByUserId: claimed.claimedByUserId,
     };
   }
+
+  private async applyPayloadToUser(userId: string, payload: PayloadShape): Promise<void> {
+    const stack = (payload.primaryStack ?? []).filter(
+      (s): s is string => typeof s === 'string' && s.length > 0,
+    );
+    const headline = typeof payload.headline === 'string' ? payload.headline : null;
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { primaryResumeId: true },
+    });
+
+    if (user?.primaryResumeId) {
+      const resume = await this.prisma.resume.findUnique({
+        where: { id: user.primaryResumeId },
+        select: { primaryStack: true, jobTitle: true },
+      });
+      const merged = Array.from(new Set([...(resume?.primaryStack ?? []), ...stack]));
+      await this.prisma.resume.update({
+        where: { id: user.primaryResumeId },
+        data: {
+          primaryStack: merged,
+          // Don't clobber a custom job title; only fill when empty.
+          jobTitle: resume?.jobTitle ?? headline,
+        },
+      });
+      return;
+    }
+
+    const created = await this.prisma.resume.create({
+      data: {
+        userId,
+        title: 'My resume',
+        primaryStack: stack,
+        jobTitle: headline,
+        contentPtBr: { sections: [] },
+      },
+    });
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { primaryResumeId: created.id },
+    });
+  }
+}
+
+interface PayloadShape {
+  headline?: string | null;
+  primaryStack?: string[];
+  projects?: Array<{ name: string; url: string; summary: string }>;
 }

--- a/src/bounded-contexts/jobs/tracker/anti-ghosting.service.ts
+++ b/src/bounded-contexts/jobs/tracker/anti-ghosting.service.ts
@@ -98,6 +98,18 @@ export class AntiGhostingService {
       };
 
       await this.remind(user.email, user.name, stale);
+
+      // Mirror the email reminder as an in-app notification so users who
+      // don't open email still see the nudge in the bell + notifications
+      // page. The notification preferences UI lets them mute it.
+      await this.prisma.notification.create({
+        data: {
+          userId: app.userId,
+          type: 'APPLICATION_STALE',
+          message: `Aplicação para ${stale.company} (${stale.jobTitle}) está há ${daysSilent} dias sem resposta. Considere enviar um follow-up.`,
+        },
+      });
+
       await this.prisma.jobApplicationReminderLog.create({
         data: { applicationId: app.id, threshold },
       });

--- a/src/bounded-contexts/notifications/controllers/notification.controller.ts
+++ b/src/bounded-contexts/notifications/controllers/notification.controller.ts
@@ -96,7 +96,7 @@ export class NotificationController {
     body: {
       enabled?: boolean;
       emailEnabled?: boolean;
-      emailDelivery?: 'INSTANT' | 'DAILY' | 'OFF';
+      emailDelivery?: 'INSTANT' | 'DAILY' | 'WEEKLY' | 'OFF';
     },
   ) {
     return this.notificationService.setPreference(req.user.userId, type, body);

--- a/src/bounded-contexts/notifications/services/notification.service.ts
+++ b/src/bounded-contexts/notifications/services/notification.service.ts
@@ -187,6 +187,9 @@ export class NotificationService {
       'CONNECTION_REQUEST',
       'CONNECTION_ACCEPTED',
       'FOLLOW_NEW',
+      'SKILL_DECAY',
+      'APPLICATION_STALE',
+      'CONNECTION_RECOMMENDATION',
     ];
     return allTypes.map((type) => {
       const o = overrideMap.get(type);
@@ -205,7 +208,7 @@ export class NotificationService {
     input: {
       enabled?: boolean;
       emailEnabled?: boolean;
-      emailDelivery?: 'INSTANT' | 'DAILY' | 'OFF';
+      emailDelivery?: 'INSTANT' | 'DAILY' | 'WEEKLY' | 'OFF';
     },
   ) {
     return this.prisma.notificationPreference.upsert({

--- a/src/bounded-contexts/notifications/services/weekly-digest.service.ts
+++ b/src/bounded-contexts/notifications/services/weekly-digest.service.ts
@@ -35,8 +35,24 @@ export class WeeklyDigestService {
     const cutoff = new Date(now.getTime() - WEEK_MS);
     const weekKey = this.isoWeekKey(now);
 
+    // Only include users who have at least one notification preference with
+    // emailDelivery=WEEKLY. Without that filter the digest would spam every
+    // active user regardless of opt-in.
+    const optedInUserIds = await this.prisma.notificationPreference
+      .findMany({
+        where: { emailDelivery: 'WEEKLY', emailEnabled: true },
+        select: { userId: true },
+        distinct: ['userId'],
+      })
+      .then((rows) => rows.map((r) => r.userId));
+
+    if (optedInUserIds.length === 0) {
+      return { usersEmailed: 0, usersSkipped: 0 };
+    }
+
     const users = await this.prisma.user.findMany({
       where: {
+        id: { in: optedInUserIds },
         email: { not: '' },
         emailVerified: { not: null },
         isActive: true,

--- a/swagger-generation-report.json
+++ b/swagger-generation-report.json
@@ -1,8 +1,8 @@
 {
   "success": true,
   "generatedBy": "nest-swagger",
-  "paths": 316,
-  "operations": 379,
+  "paths": 317,
+  "operations": 380,
   "schemas": 267,
   "tags": [
     "auth",

--- a/swagger.json
+++ b/swagger.json
@@ -12877,7 +12877,42 @@
             "bearer": []
           }
         ],
-        "summary": "Run a resume AST through the ATS parser simulator and return the extracted text + warnings.",
+        "summary": "Run an explicit AtsSimulationInput payload through the simulator. Use this when the caller has already shaped the AST.",
+        "tags": [
+          "ats"
+        ]
+      }
+    },
+    "/api/v1/ats/simulate/{resumeId}": {
+      "get": {
+        "operationId": "ats_simulateForResume",
+        "parameters": [
+          {
+            "name": "resumeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Requires permission: resume:read"
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Convenience endpoint: load a resume by id, map it to AtsSimulationInput, and run the simulator in one call.",
         "tags": [
           "ats"
         ]


### PR DESCRIPTION
## Why

The UI batch I just shipped to \`patch-careers-ui\` references several backend behaviours that didn't exist yet. This PR closes those gaps so the UI doesn't get 400s / silent no-ops.

## Changes

- \`EmailDeliveryMode\` gains \`WEEKLY\`. WeeklyDigestService now filters by it instead of emailing every active user.
- \`NotificationService.getPreferences\` returns the 3 new types added in #201 (SKILL_DECAY, APPLICATION_STALE, CONNECTION_RECOMMENDATION) so toggles render.
- OAuth callback forwards \`email\` and (github only) \`githubLogin\` as URL params for the shadow-profile probe.
- \`ShadowProfileService.claimForUser\` actually merges payload into the user's primary resume (creating one if needed). Was no-op before.
- New \`GET /api/v1/ats/simulate/:resumeId\` — loads resume, maps to simulator shape, runs simulator in one call. Logic in AtsSimulatorService to keep controller thin.
- AntiGhostingService also writes an in-app \`APPLICATION_STALE\` Notification alongside the email so the bell shows it.

## Migration

\`20260419221438_email_delivery_weekly\` — adds \`WEEKLY\` to the enum.

Pre-commit: typecheck / lint / unit (2876) / arch / contract all green.