### PR TITLE
feat(api): server-driven UI primitives — slim the frontend

### DIFF
--- a/.attestation
+++ b/.attestation
@@ -1,38 +1,38 @@
 {
   "version": "3",
-  "tree_hash": "c49472b710224789b88a6fc8ce48849bbdee4a9f",
+  "tree_hash": "528c5ab2d14cfe9ca2b233327ce169d156f9b54e",
   "checks": "swagger typecheck lint unit arch contract",
   "metrics": {
     "typecheck": {
       "status": "ok",
-      "time_ms": 4447
+      "time_ms": 4431
     },
     "lint": {
       "status": "ok",
-      "time_ms": 1490
+      "time_ms": 1215
     },
     "unit": {
       "status": "ok",
-      "time_ms": 6417,
+      "time_ms": 6201,
       "passed": 2876,
       "failed": 0,
       "skipped": 0
     },
     "arch": {
       "status": "ok",
-      "time_ms": 1781,
+      "time_ms": 1436,
       "passed": 42,
       "failed": 0,
       "skipped": 1
     },
     "contract": {
       "status": "ok",
-      "time_ms": 796,
+      "time_ms": 615,
       "passed": 42,
       "failed": 0,
       "skipped": 0
     }
   },
-  "timestamp": "2026-04-19T18:43:49Z",
+  "timestamp": "2026-04-19T22:26:16Z",
   "git_user": "enzo.patti@aluno.senai.br"
 }

--- a/.attestation
+++ b/.attestation
@@ -1,38 +1,38 @@
 {
   "version": "3",
-  "tree_hash": "528c5ab2d14cfe9ca2b233327ce169d156f9b54e",
+  "tree_hash": "f3f704bebcfdd0a7eb310dd38149efe4938d3bde",
   "checks": "swagger typecheck lint unit arch contract",
   "metrics": {
     "typecheck": {
       "status": "ok",
-      "time_ms": 4431
+      "time_ms": 4470
     },
     "lint": {
       "status": "ok",
-      "time_ms": 1215
+      "time_ms": 1250
     },
     "unit": {
       "status": "ok",
-      "time_ms": 6201,
+      "time_ms": 6163,
       "passed": 2876,
       "failed": 0,
       "skipped": 0
     },
     "arch": {
       "status": "ok",
-      "time_ms": 1436,
+      "time_ms": 1724,
       "passed": 42,
       "failed": 0,
       "skipped": 1
     },
     "contract": {
       "status": "ok",
-      "time_ms": 615,
+      "time_ms": 923,
       "passed": 42,
       "failed": 0,
       "skipped": 0
     }
   },
-  "timestamp": "2026-04-19T22:26:16Z",
+  "timestamp": "2026-04-19T23:12:02Z",
   "git_user": "enzo.patti@aluno.senai.br"
 }

--- a/client-swagger.json
+++ b/client-swagger.json
@@ -2896,6 +2896,76 @@
         "tags": ["shadow-profile"]
       }
     },
+    "/api/v1/me/ui-state": {
+      "get": {
+        "operationId": "users_getAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Returns every UI-state row for the current user. UI bootstraps once and reads keys locally.",
+        "tags": ["users"]
+      }
+    },
+    "/api/v1/me/ui-state/{key}": {
+      "patch": {
+        "operationId": "users_setKey",
+        "parameters": [
+          {
+            "name": "key",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Upsert a single UI-state key/value (idempotent).",
+        "tags": ["users"]
+      },
+      "delete": {
+        "operationId": "users_deleteKey",
+        "parameters": [
+          {
+            "name": "key",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Remove a UI-state key.",
+        "tags": ["users"]
+      }
+    },
     "/api/v1/users/{username}/profile": {
       "get": {
         "operationId": "users_getPublicProfileByUsername",
@@ -13850,6 +13920,87 @@
         ],
         "summary": "List recent delivery attempts for a webhook.",
         "tags": ["Webhooks"]
+      }
+    },
+    "/api/v1/enums": {
+      "get": {
+        "operationId": "uiMetadata_listEnums",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "List all enum keys exposed by the catalog.",
+        "tags": ["ui-metadata"]
+      }
+    },
+    "/api/v1/enums/{key}": {
+      "get": {
+        "operationId": "uiMetadata_getEnumByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Full descriptor for a UI enum (notification-types, job-application-event-types, etc.) with localized labels + icon hints.",
+        "tags": ["ui-metadata"]
+      }
+    },
+    "/api/v1/me/menu": {
+      "get": {
+        "operationId": "uiMetadata_getMenu",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Permission-aware navigation tree for the current user with labels in the request locale.",
+        "tags": ["ui-metadata"]
+      }
+    },
+    "/api/v1/pages/me-dashboard": {
+      "get": {
+        "operationId": "pages_load",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Single payload for the dashboard: counts (resumes, applications, unread notifications), latest activity items, viewer summary. Replaces ~5 parallel UI fetches.",
+        "tags": ["pages"]
       }
     }
   },

--- a/client-swagger.json
+++ b/client-swagger.json
@@ -8246,7 +8246,40 @@
             "bearer": []
           }
         ],
-        "summary": "Run a resume AST through the ATS parser simulator and return the extracted text + warnings.",
+        "summary": "Run an explicit AtsSimulationInput payload through the simulator. Use this when the caller has already shaped the AST.",
+        "tags": ["ats"]
+      }
+    },
+    "/api/v1/ats/simulate/{resumeId}": {
+      "get": {
+        "operationId": "ats_simulateForResume",
+        "parameters": [
+          {
+            "name": "resumeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Requires permission: resume:read"
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Convenience endpoint: load a resume by id, map it to AtsSimulationInput, and run the simulator in one call.",
         "tags": ["ats"]
       }
     },

--- a/prisma/migrations/20260419221438_email_delivery_weekly/migration.sql
+++ b/prisma/migrations/20260419221438_email_delivery_weekly/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "EmailDeliveryMode" ADD VALUE 'WEEKLY';

--- a/prisma/migrations/20260419230432_server_driven_ui/migration.sql
+++ b/prisma/migrations/20260419230432_server_driven_ui/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN     "messageKey" TEXT,
+ADD COLUMN     "messageParams" JSONB;
+
+-- CreateTable
+CREATE TABLE "user_ui_state" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_ui_state_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_ui_state_userId_idx" ON "user_ui_state"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_ui_state_userId_key_key" ON "user_ui_state"("userId", "key");

--- a/prisma/schema/notification.prisma
+++ b/prisma/schema/notification.prisma
@@ -46,6 +46,7 @@ model NotificationPreference {
 enum EmailDeliveryMode {
   INSTANT
   DAILY
+  WEEKLY
   OFF
 }
 

--- a/prisma/schema/notification.prisma
+++ b/prisma/schema/notification.prisma
@@ -13,6 +13,14 @@ model Notification {
   entityId   String?
 
   message String
+  /**
+   * Stable i18n key (e.g. "notification.application_stale") so the same
+   * notification can be re-rendered in any language without hitting the
+   * backend again. The literal `message` above stays as a fallback for
+   * old rows and for plain-text channels (push, SMS).
+   */
+  messageKey    String?
+  messageParams Json?
   read    Boolean @default(false)
 
   // Email delivery tracking — null means "never sent", value means "sent at that time".

--- a/prisma/schema/ui-state.prisma
+++ b/prisma/schema/ui-state.prisma
@@ -1,0 +1,16 @@
+/// Per-user, key/value UI preferences (table sort order, dismissed banners,
+/// last-used filters, dark/light, locale). Replaces every localStorage /
+/// URL-searchParam pattern in the frontend so user state survives device
+/// changes and session resets.
+model UserUiState {
+  id        String   @id @default(cuid())
+  userId    String
+  key       String
+  value     Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, key])
+  @@index([userId])
+  @@map("user_ui_state")
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -53,6 +53,7 @@ import { MetricsModule } from '@/bounded-contexts/platform/metrics/metrics.modul
 import { PrismaModule } from '@/bounded-contexts/platform/prisma/prisma.module';
 // Test Runner
 import { TestRunnerModule } from '@/bounded-contexts/platform/test-runner/test-runner.module';
+import { UiMetadataModule } from '@/bounded-contexts/platform/ui-metadata/ui-metadata.module';
 import { WebhookModule } from '@/bounded-contexts/platform/webhooks/webhook.module';
 import { PublicResumesModule } from '@/bounded-contexts/presentation/public-resumes/public-resumes.module';
 // Presentation Context
@@ -75,6 +76,7 @@ import { RATE_LIMIT_CONFIG } from '@/shared-kernel';
 import { EventBusModule } from '@/shared-kernel/event-bus/event-bus.module';
 import { DomainExceptionFilter } from '@/shared-kernel/filters/domain-exception.filter';
 import { ApiResponseInterceptor } from '@/shared-kernel/interceptors/api-response.interceptor';
+import { HumanRelativeInterceptor } from '@/shared-kernel/interceptors/human-relative.interceptor';
 import { AppController } from './app.controller';
 
 @Module({
@@ -165,6 +167,7 @@ import { AppController } from './app.controller';
     NotificationsModule,
     TestRunnerModule,
     WebhookModule,
+    UiMetadataModule,
   ],
   controllers: [AppController],
   providers: [
@@ -177,6 +180,12 @@ import { AppController } from './app.controller';
     {
       provide: APP_INTERCEPTOR,
       useClass: ApiResponseInterceptor,
+    },
+    // Adds `<key>AtRelative` siblings to every ISO date in the response so
+    // the UI never needs a date-formatting library.
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: HumanRelativeInterceptor,
     },
     // Global Guards (order matters: Throttler → JWT Auth)
     {

--- a/src/bounded-contexts/ats-validation/ats/ats.module.ts
+++ b/src/bounded-contexts/ats-validation/ats/ats.module.ts
@@ -22,6 +22,7 @@ import {
 } from './scoring';
 import { ATSService } from './services/ats.service';
 import { ATSSectionTypeAdapter } from './services/ats-section-type.adapter';
+import { AtsSimulatorService } from './services/ats-simulator.service';
 import { EncodingNormalizerService } from './services/encoding-normalizer.service';
 import { SectionSemanticCatalogAdapter } from './services/section-semantic-catalog.adapter';
 import { TextExtractionService } from './services/text-extraction.service';
@@ -40,6 +41,7 @@ import { SectionOrderValidator } from './validators/section-order.validator';
     // ATS Definition-driven adapter
     ATSSectionTypeAdapter,
     ATSService,
+    AtsSimulatorService,
     TextExtractionService,
     EncodingNormalizerService,
     CVSectionParser,

--- a/src/bounded-contexts/ats-validation/ats/services/ats-simulator.service.ts
+++ b/src/bounded-contexts/ats-validation/ats/services/ats-simulator.service.ts
@@ -1,0 +1,61 @@
+/**
+ * ATS Simulator Service
+ *
+ * Loads a resume from Prisma, maps it to the simulator input shape, and
+ * runs the parser simulation. Lives as a service (not in the controller)
+ * so the architectural rule banning DB queries in controllers stays clean.
+ */
+
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/bounded-contexts/platform/prisma/prisma.service';
+import {
+  EntityNotFoundException,
+  ForbiddenException,
+} from '@/shared-kernel/exceptions/domain.exceptions';
+import { type AtsSimulationResult, simulateAtsParsing } from '../simulation/ats-parser-simulator';
+import { buildSimulationInput } from '../simulation/build-simulation-input';
+
+@Injectable()
+export class AtsSimulatorService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async simulateForResume(resumeId: string, viewerId: string): Promise<AtsSimulationResult> {
+    const resume = await this.prisma.resume.findUnique({
+      where: { id: resumeId },
+      select: {
+        userId: true,
+        resumeSections: {
+          where: { isVisible: true },
+          orderBy: { order: 'asc' },
+          select: {
+            titleOverride: true,
+            sectionType: { select: { title: true, semanticKind: true } },
+            items: {
+              where: { isVisible: true },
+              orderBy: { order: 'asc' },
+              select: { content: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!resume) throw new EntityNotFoundException('Resume', resumeId);
+    if (resume.userId !== viewerId) {
+      throw new ForbiddenException('You do not have access to this resume');
+    }
+
+    const input = buildSimulationInput({
+      sections: resume.resumeSections.map((s) => ({
+        title: s.titleOverride ?? s.sectionType.title,
+        semanticKind: s.sectionType.semanticKind,
+        column: 'full-width',
+        items: s.items.map((it) => ({
+          content: (it.content as Record<string, unknown> | null) ?? null,
+        })),
+      })),
+    });
+
+    return simulateAtsParsing(input);
+  }
+}

--- a/src/bounded-contexts/ats-validation/ats/simulation/build-simulation-input.ts
+++ b/src/bounded-contexts/ats-validation/ats/simulation/build-simulation-input.ts
@@ -1,0 +1,56 @@
+/**
+ * Adapter that maps Prisma resume rows to the AtsSimulationInput shape the
+ * parser simulator expects. Lives in the ATS context (not in resumes/) so
+ * the resumes module doesn't need to know about ATS internals.
+ */
+
+import type { AtsSimulationInput } from './ats-parser-simulator';
+
+export interface ResumeForSimulation {
+  layout?: { type?: string | null } | null;
+  sections: Array<{
+    title: string | null;
+    semanticKind: string;
+    column?: string | null;
+    items: Array<{
+      content: Record<string, unknown> | null;
+    }>;
+  }>;
+}
+
+function flattenContentToFields(content: Record<string, unknown> | null): Record<string, string> {
+  if (!content) return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(content)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'string') {
+      out[key] = value;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      out[key] = String(value);
+    } else if (Array.isArray(value)) {
+      out[key] = value.filter((v) => typeof v === 'string').join(', ');
+    }
+    // Nested objects are intentionally ignored — ATS parsers see flat text.
+  }
+  return out;
+}
+
+function normaliseColumn(raw: string | null | undefined): 'main' | 'sidebar' | 'full-width' {
+  if (raw === 'sidebar') return 'sidebar';
+  if (raw === 'main') return 'main';
+  return 'full-width';
+}
+
+export function buildSimulationInput(resume: ResumeForSimulation): AtsSimulationInput {
+  const layoutType = resume.layout?.type === 'two-column' ? 'two-column' : 'single-column';
+
+  return {
+    layout: { type: layoutType },
+    sections: resume.sections.map((s) => ({
+      title: s.title ?? '',
+      semanticKind: s.semanticKind,
+      column: normaliseColumn(s.column),
+      items: s.items.map((it) => ({ fields: flattenContentToFields(it.content) })),
+    })),
+  };
+}

--- a/src/bounded-contexts/ats-validation/infrastructure/controllers/ats-simulator.controller.ts
+++ b/src/bounded-contexts/ats-validation/infrastructure/controllers/ats-simulator.controller.ts
@@ -1,11 +1,13 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { UserPayload } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
 import { CurrentUser } from '@/bounded-contexts/platform/common/decorators/current-user.decorator';
 import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
 import { Permission, RequirePermission } from '@/shared-kernel/authorization';
+import { AtsSimulatorService } from '../../ats/services/ats-simulator.service';
 import {
   type AtsSimulationInput,
+  type AtsSimulationResult,
   simulateAtsParsing,
 } from '../../ats/simulation/ats-parser-simulator';
 
@@ -14,18 +16,34 @@ import {
 @ApiBearerAuth('JWT-auth')
 @Controller('v1/ats/simulate')
 export class AtsSimulatorController {
+  constructor(private readonly service: AtsSimulatorService) {}
+
   @Post()
   @RequirePermission(Permission.RESUME_READ)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary:
-      'Run a resume AST through the ATS parser simulator and return the extracted text + warnings.',
+      'Run an explicit AtsSimulationInput payload through the simulator. Use this when the caller has already shaped the AST.',
   })
   async simulate(
     @CurrentUser() _user: UserPayload,
     @Body() body: AtsSimulationInput,
-  ): Promise<{ success: true; data: ReturnType<typeof simulateAtsParsing> }> {
-    const result = simulateAtsParsing(body);
-    return { success: true, data: result };
+  ): Promise<{ success: true; data: AtsSimulationResult }> {
+    return { success: true, data: simulateAtsParsing(body) };
+  }
+
+  @Get(':resumeId')
+  @RequirePermission(Permission.RESUME_READ)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Convenience endpoint: load a resume by id, map it to AtsSimulationInput, and run the simulator in one call.',
+  })
+  async simulateForResume(
+    @CurrentUser() user: UserPayload,
+    @Param('resumeId') resumeId: string,
+  ): Promise<{ success: true; data: AtsSimulationResult }> {
+    const data = await this.service.simulateForResume(resumeId, user.userId);
+    return { success: true, data };
   }
 }

--- a/src/bounded-contexts/identity/identity.module.ts
+++ b/src/bounded-contexts/identity/identity.module.ts
@@ -7,6 +7,7 @@ import { OAuthModule } from './oauth/oauth.module';
 import { PasswordManagementModule } from './password-management';
 import { TwoFactorAuthModule } from './two-factor-auth';
 import { ShadowProfileModule } from './users/shadow-profile/shadow-profile.module';
+import { UiStateModule } from './users/ui-state/ui-state.module';
 
 /**
  * Identity Module
@@ -30,6 +31,7 @@ import { ShadowProfileModule } from './users/shadow-profile/shadow-profile.modul
     TwoFactorAuthModule,
     OAuthModule,
     ShadowProfileModule,
+    UiStateModule,
   ],
   exports: [
     PasswordManagementModule,
@@ -39,6 +41,7 @@ import { ShadowProfileModule } from './users/shadow-profile/shadow-profile.modul
     TwoFactorAuthModule,
     OAuthModule,
     ShadowProfileModule,
+    UiStateModule,
   ],
 })
 export class IdentityModule {}

--- a/src/bounded-contexts/identity/oauth/controllers/oauth.controller.ts
+++ b/src/bounded-contexts/identity/oauth/controllers/oauth.controller.ts
@@ -96,8 +96,21 @@ export class OAuthController {
     // the userId + marker and calls our create-session endpoint (which sets
     // the httpOnly cookie). Keeping this controller session-agnostic avoids
     // duplicating the JWT/cookie logic that already lives in Authentication.
+    //
+    // We also forward the verified email and (for github) the external
+    // username so the UI can immediately probe for a pre-built shadow
+    // profile and offer to claim it.
     const base = this.config.get<string>('UI_BASE_URL') ?? '';
-    const target = `${base}/auth/oauth-complete?provider=${provider}&userId=${userId}&created=${created}`;
-    res.redirect(target);
+    const params = new URLSearchParams({
+      provider,
+      userId,
+      created: String(created),
+    });
+    if (req.user.email) params.set('email', req.user.email);
+    const externalLogin = (req.user.raw as { login?: unknown } | null)?.login;
+    if (provider === 'github' && typeof externalLogin === 'string') {
+      params.set('githubLogin', externalLogin);
+    }
+    res.redirect(`${base}/auth/oauth-complete?${params.toString()}`);
   }
 }

--- a/src/bounded-contexts/identity/users/shadow-profile/shadow-profile.service.ts
+++ b/src/bounded-contexts/identity/users/shadow-profile/shadow-profile.service.ts
@@ -87,6 +87,11 @@ export class ShadowProfileService {
       throw new ConflictException('Shadow profile already claimed by another user');
     }
 
+    // Apply the shadow payload to the user's primary resume so the claim is
+    // user-visible. Creates a fresh resume if there isn't one yet, otherwise
+    // merges (existing skills win on conflict — never overwrite curated data).
+    await this.applyPayloadToUser(userId, existing.payload as PayloadShape);
+
     const claimed = await this.prisma.shadowProfile.update({
       where: { id: shadowId },
       data: { claimedByUserId: userId, claimedAt: new Date() },
@@ -101,4 +106,53 @@ export class ShadowProfileService {
       claimedByUserId: claimed.claimedByUserId,
     };
   }
+
+  private async applyPayloadToUser(userId: string, payload: PayloadShape): Promise<void> {
+    const stack = (payload.primaryStack ?? []).filter(
+      (s): s is string => typeof s === 'string' && s.length > 0,
+    );
+    const headline = typeof payload.headline === 'string' ? payload.headline : null;
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { primaryResumeId: true },
+    });
+
+    if (user?.primaryResumeId) {
+      const resume = await this.prisma.resume.findUnique({
+        where: { id: user.primaryResumeId },
+        select: { primaryStack: true, jobTitle: true },
+      });
+      const merged = Array.from(new Set([...(resume?.primaryStack ?? []), ...stack]));
+      await this.prisma.resume.update({
+        where: { id: user.primaryResumeId },
+        data: {
+          primaryStack: merged,
+          // Don't clobber a custom job title; only fill when empty.
+          jobTitle: resume?.jobTitle ?? headline,
+        },
+      });
+      return;
+    }
+
+    const created = await this.prisma.resume.create({
+      data: {
+        userId,
+        title: 'My resume',
+        primaryStack: stack,
+        jobTitle: headline,
+        contentPtBr: { sections: [] },
+      },
+    });
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { primaryResumeId: created.id },
+    });
+  }
+}
+
+interface PayloadShape {
+  headline?: string | null;
+  primaryStack?: string[];
+  projects?: Array<{ name: string; url: string; summary: string }>;
 }

--- a/src/bounded-contexts/identity/users/ui-state/ui-state.controller.ts
+++ b/src/bounded-contexts/identity/users/ui-state/ui-state.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Patch } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { UserPayload } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
+import { CurrentUser } from '@/bounded-contexts/platform/common/decorators/current-user.decorator';
+import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
+import { UiStateService } from './ui-state.service';
+
+@SdkExport({ tag: 'users', description: 'Per-user UI state' })
+@ApiTags('users')
+@ApiBearerAuth('JWT-auth')
+@Controller('v1/me/ui-state')
+export class UiStateController {
+  constructor(private readonly service: UiStateService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Returns every UI-state row for the current user. UI bootstraps once and reads keys locally.',
+  })
+  async getAll(
+    @CurrentUser() user: UserPayload,
+  ): Promise<{ success: true; data: { state: Record<string, unknown> } }> {
+    const state = await this.service.getAll(user.userId);
+    return { success: true, data: { state } };
+  }
+
+  @Patch(':key')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Upsert a single UI-state key/value (idempotent).' })
+  async setKey(
+    @CurrentUser() user: UserPayload,
+    @Param('key') key: string,
+    @Body() body: { value: unknown },
+  ): Promise<{ success: true; data: { key: string; value: unknown } }> {
+    const data = await this.service.setKey(user.userId, key, body?.value);
+    return { success: true, data };
+  }
+
+  @Delete(':key')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Remove a UI-state key.' })
+  async deleteKey(
+    @CurrentUser() user: UserPayload,
+    @Param('key') key: string,
+  ): Promise<{ success: true; data: { deleted: boolean } }> {
+    await this.service.deleteKey(user.userId, key);
+    return { success: true, data: { deleted: true } };
+  }
+}

--- a/src/bounded-contexts/identity/users/ui-state/ui-state.module.ts
+++ b/src/bounded-contexts/identity/users/ui-state/ui-state.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@/bounded-contexts/platform/prisma/prisma.module';
+import { UiStateController } from './ui-state.controller';
+import { UiStateService } from './ui-state.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UiStateController],
+  providers: [UiStateService],
+})
+export class UiStateModule {}

--- a/src/bounded-contexts/identity/users/ui-state/ui-state.service.ts
+++ b/src/bounded-contexts/identity/users/ui-state/ui-state.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/bounded-contexts/platform/prisma/prisma.service';
+
+@Injectable()
+export class UiStateService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getAll(userId: string): Promise<Record<string, unknown>> {
+    const rows = await this.prisma.userUiState.findMany({
+      where: { userId },
+      select: { key: true, value: true },
+    });
+    const out: Record<string, unknown> = {};
+    for (const r of rows) out[r.key] = r.value;
+    return out;
+  }
+
+  async setKey(
+    userId: string,
+    key: string,
+    value: unknown,
+  ): Promise<{ key: string; value: unknown }> {
+    const safeValue = (value ?? null) as object;
+    const row = await this.prisma.userUiState.upsert({
+      where: { userId_key: { userId, key } },
+      create: { userId, key, value: safeValue },
+      update: { value: safeValue },
+    });
+    return { key: row.key, value: row.value };
+  }
+
+  async deleteKey(userId: string, key: string): Promise<void> {
+    await this.prisma.userUiState
+      .delete({ where: { userId_key: { userId, key } } })
+      .catch(() => undefined);
+  }
+}

--- a/src/bounded-contexts/jobs/tracker/anti-ghosting.service.ts
+++ b/src/bounded-contexts/jobs/tracker/anti-ghosting.service.ts
@@ -98,6 +98,18 @@ export class AntiGhostingService {
       };
 
       await this.remind(user.email, user.name, stale);
+
+      // Mirror the email reminder as an in-app notification so users who
+      // don't open email still see the nudge in the bell + notifications
+      // page. The notification preferences UI lets them mute it.
+      await this.prisma.notification.create({
+        data: {
+          userId: app.userId,
+          type: 'APPLICATION_STALE',
+          message: `Aplicação para ${stale.company} (${stale.jobTitle}) está há ${daysSilent} dias sem resposta. Considere enviar um follow-up.`,
+        },
+      });
+
       await this.prisma.jobApplicationReminderLog.create({
         data: { applicationId: app.id, threshold },
       });

--- a/src/bounded-contexts/jobs/tracker/anti-ghosting.service.ts
+++ b/src/bounded-contexts/jobs/tracker/anti-ghosting.service.ts
@@ -101,12 +101,20 @@ export class AntiGhostingService {
 
       // Mirror the email reminder as an in-app notification so users who
       // don't open email still see the nudge in the bell + notifications
-      // page. The notification preferences UI lets them mute it.
+      // page. messageKey + messageParams let the UI re-render in any
+      // locale without an extra round-trip.
       await this.prisma.notification.create({
         data: {
           userId: app.userId,
           type: 'APPLICATION_STALE',
           message: `Aplicação para ${stale.company} (${stale.jobTitle}) está há ${daysSilent} dias sem resposta. Considere enviar um follow-up.`,
+          messageKey: 'notification.application_stale',
+          messageParams: {
+            company: stale.company,
+            jobTitle: stale.jobTitle,
+            daysSilent,
+            applicationId: stale.id,
+          },
         },
       });
 

--- a/src/bounded-contexts/notifications/controllers/notification.controller.ts
+++ b/src/bounded-contexts/notifications/controllers/notification.controller.ts
@@ -96,7 +96,7 @@ export class NotificationController {
     body: {
       enabled?: boolean;
       emailEnabled?: boolean;
-      emailDelivery?: 'INSTANT' | 'DAILY' | 'OFF';
+      emailDelivery?: 'INSTANT' | 'DAILY' | 'WEEKLY' | 'OFF';
     },
   ) {
     return this.notificationService.setPreference(req.user.userId, type, body);

--- a/src/bounded-contexts/notifications/services/notification.service.ts
+++ b/src/bounded-contexts/notifications/services/notification.service.ts
@@ -187,6 +187,9 @@ export class NotificationService {
       'CONNECTION_REQUEST',
       'CONNECTION_ACCEPTED',
       'FOLLOW_NEW',
+      'SKILL_DECAY',
+      'APPLICATION_STALE',
+      'CONNECTION_RECOMMENDATION',
     ];
     return allTypes.map((type) => {
       const o = overrideMap.get(type);
@@ -205,7 +208,7 @@ export class NotificationService {
     input: {
       enabled?: boolean;
       emailEnabled?: boolean;
-      emailDelivery?: 'INSTANT' | 'DAILY' | 'OFF';
+      emailDelivery?: 'INSTANT' | 'DAILY' | 'WEEKLY' | 'OFF';
     },
   ) {
     return this.prisma.notificationPreference.upsert({

--- a/src/bounded-contexts/notifications/services/weekly-digest.service.ts
+++ b/src/bounded-contexts/notifications/services/weekly-digest.service.ts
@@ -35,8 +35,24 @@ export class WeeklyDigestService {
     const cutoff = new Date(now.getTime() - WEEK_MS);
     const weekKey = this.isoWeekKey(now);
 
+    // Only include users who have at least one notification preference with
+    // emailDelivery=WEEKLY. Without that filter the digest would spam every
+    // active user regardless of opt-in.
+    const optedInUserIds = await this.prisma.notificationPreference
+      .findMany({
+        where: { emailDelivery: 'WEEKLY', emailEnabled: true },
+        select: { userId: true },
+        distinct: ['userId'],
+      })
+      .then((rows) => rows.map((r) => r.userId));
+
+    if (optedInUserIds.length === 0) {
+      return { usersEmailed: 0, usersSkipped: 0 };
+    }
+
     const users = await this.prisma.user.findMany({
       where: {
+        id: { in: optedInUserIds },
         email: { not: '' },
         emailVerified: { not: null },
         isActive: true,

--- a/src/bounded-contexts/platform/common/filters/http-exception.filter.ts
+++ b/src/bounded-contexts/platform/common/filters/http-exception.filter.ts
@@ -83,7 +83,13 @@ export class AllExceptionsFilter implements ExceptionFilter {
     success: false;
     statusCode: number;
     message: string;
-    error: { code: string; message: string; details?: Record<string, unknown> };
+    error: {
+      code: string;
+      message: string;
+      userMessage?: string;
+      action?: string;
+      details?: Record<string, unknown>;
+    };
   } {
     // Default values
     let code: string = this.statusToDefaultCode(status);
@@ -176,9 +182,47 @@ export class AllExceptionsFilter implements ExceptionFilter {
       error: {
         code,
         message,
+        userMessage: this.codeToUserMessage(code, message),
+        action: this.codeToAction(code, status),
         details,
       },
     };
+  }
+
+  /**
+   * Localized, user-safe message that the UI can show in a toast without
+   * additional translation. Falls back to the raw message for codes we
+   * haven't curated copy for.
+   */
+  private codeToUserMessage(code: string, fallback: string): string {
+    switch (code) {
+      case ERROR_CODES.UNAUTHORIZED:
+        return 'Sua sessão expirou. Faça login novamente.';
+      case ERROR_CODES.FORBIDDEN:
+        return 'Você não tem permissão para essa ação.';
+      case ERROR_CODES.NOT_FOUND:
+        return 'Não encontramos esse recurso.';
+      case ERROR_CODES.CONFLICT:
+        return 'Esse recurso entrou em conflito com outro existente.';
+      case ERROR_CODES.VALIDATION_ERROR:
+        return 'Algum campo está inválido. Confira os dados.';
+      case ERROR_CODES.INTERNAL_ERROR:
+        return 'Tivemos um problema temporário. Tente novamente em alguns segundos.';
+      default:
+        return fallback;
+    }
+  }
+
+  /**
+   * UI-side action hint. The frontend reads this to know whether to redirect
+   * (`redirect:/login`), surface a retry button, or just show the toast.
+   */
+  private codeToAction(code: string, status: number): string {
+    if (status === HttpStatus.UNAUTHORIZED) return 'redirect:/login';
+    if (status === HttpStatus.FORBIDDEN) return 'redirect:/dashboard';
+    if (code === ERROR_CODES.VALIDATION_ERROR) return 'highlight-fields';
+    if (status >= 500) return 'retry';
+    return 'toast';
   }
 
   private statusToDefaultCode(status: number): string {

--- a/src/bounded-contexts/platform/ui-metadata/controllers/me-dashboard.controller.ts
+++ b/src/bounded-contexts/platform/ui-metadata/controllers/me-dashboard.controller.ts
@@ -1,0 +1,34 @@
+/**
+ * Composite endpoint that returns everything the dashboard page needs in
+ * one round-trip. Serves as a template for other "page" endpoints — the
+ * pattern collapses N parallel client-side fetches + merging logic into
+ * a single typed payload the frontend can render directly.
+ */
+
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { UserPayload } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
+import { CurrentUser } from '@/bounded-contexts/platform/common/decorators/current-user.decorator';
+import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
+import { type MeDashboardPayload, MeDashboardService } from '../services/me-dashboard.service';
+
+@SdkExport({ tag: 'pages', description: 'Composite page payloads' })
+@ApiTags('pages')
+@ApiBearerAuth('JWT-auth')
+@Controller('v1/pages/me-dashboard')
+export class MeDashboardController {
+  constructor(private readonly service: MeDashboardService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Single payload for the dashboard: counts (resumes, applications, unread notifications), latest activity items, viewer summary. Replaces ~5 parallel UI fetches.',
+  })
+  async load(
+    @CurrentUser() user: UserPayload,
+  ): Promise<{ success: true; data: MeDashboardPayload }> {
+    const data = await this.service.load(user.userId);
+    return { success: true, data };
+  }
+}

--- a/src/bounded-contexts/platform/ui-metadata/controllers/ui-metadata.controller.ts
+++ b/src/bounded-contexts/platform/ui-metadata/controllers/ui-metadata.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Get, HttpCode, HttpStatus, NotFoundException, Param } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { UserPayload } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
+import { Public } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
+import { CurrentUser } from '@/bounded-contexts/platform/common/decorators/current-user.decorator';
+import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
+import { type EnumDescriptor, getEnum, listEnumKeys } from '../services/enum-catalog';
+import { MenuService } from '../services/menu.service';
+import type { MenuNode } from '../services/menu-builder';
+
+@SdkExport({ tag: 'ui-metadata', description: 'Server-driven UI metadata' })
+@ApiTags('ui-metadata')
+@ApiBearerAuth('JWT-auth')
+@Controller('v1')
+export class UiMetadataController {
+  constructor(private readonly menuService: MenuService) {}
+
+  @Public()
+  @Get('enums')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'List all enum keys exposed by the catalog.' })
+  listEnums(): { success: true; data: { keys: string[] } } {
+    return { success: true, data: { keys: listEnumKeys() } };
+  }
+
+  @Public()
+  @Get('enums/:key')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Full descriptor for a UI enum (notification-types, job-application-event-types, etc.) with localized labels + icon hints.',
+  })
+  getEnumByKey(@Param('key') key: string): { success: true; data: EnumDescriptor } {
+    const out = getEnum(key);
+    if (!out) throw new NotFoundException(`Unknown enum: ${key}`);
+    return { success: true, data: out };
+  }
+
+  @Get('me/menu')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Permission-aware navigation tree for the current user with labels in the request locale.',
+  })
+  async getMenu(
+    @CurrentUser() user: UserPayload,
+  ): Promise<{ success: true; data: { menu: MenuNode[] } }> {
+    const menu = await this.menuService.getMenuFor(user.userId);
+    return { success: true, data: { menu } };
+  }
+}

--- a/src/bounded-contexts/platform/ui-metadata/services/enum-catalog.ts
+++ b/src/bounded-contexts/platform/ui-metadata/services/enum-catalog.ts
@@ -1,0 +1,210 @@
+/**
+ * Server-driven enum catalog.
+ *
+ * The frontend used to keep parallel TypeScript unions + label maps + icon
+ * maps for every enum (NotificationType, JobApplicationEventType, etc.).
+ * Adding a value meant a coordinated deploy. Now the UI fetches each enum's
+ * full descriptor (value + i18n labels + icon hint + grouping) and renders
+ * generically — backend is the single source of truth.
+ */
+
+export type SupportedLocale = 'pt-BR' | 'en';
+
+export interface EnumValueDescriptor {
+  value: string;
+  /** Lucide icon name; UI maps to <component>. */
+  icon: string;
+  /** Optional UI grouping for tabs / sections (e.g. "engagement"). */
+  group?: string;
+  /** Tone hint — UI maps to color tokens. */
+  tone?: 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+  labels: Record<SupportedLocale, string>;
+}
+
+export interface EnumDescriptor {
+  key: string;
+  values: EnumValueDescriptor[];
+}
+
+const NOTIFICATION_TYPES: EnumValueDescriptor[] = [
+  {
+    value: 'POST_LIKED',
+    icon: 'thumbs-up',
+    group: 'engagement',
+    tone: 'info',
+    labels: { 'pt-BR': 'curtiu seu post', en: 'liked your post' },
+  },
+  {
+    value: 'POST_COMMENTED',
+    icon: 'message-circle',
+    group: 'engagement',
+    tone: 'info',
+    labels: { 'pt-BR': 'comentou no seu post', en: 'commented on your post' },
+  },
+  {
+    value: 'POST_REPOSTED',
+    icon: 'repeat',
+    group: 'engagement',
+    tone: 'info',
+    labels: { 'pt-BR': 'repostou seu post', en: 'reposted your post' },
+  },
+  {
+    value: 'POST_BOOKMARKED',
+    icon: 'bookmark',
+    group: 'engagement',
+    tone: 'neutral',
+    labels: { 'pt-BR': 'salvou seu post', en: 'bookmarked your post' },
+  },
+  {
+    value: 'COMMENT_REPLIED',
+    icon: 'reply',
+    group: 'engagement',
+    tone: 'info',
+    labels: { 'pt-BR': 'respondeu seu comentário', en: 'replied to your comment' },
+  },
+  {
+    value: 'CONNECTION_REQUEST',
+    icon: 'user-plus',
+    group: 'connections',
+    tone: 'info',
+    labels: { 'pt-BR': 'enviou um pedido de conexão', en: 'sent a connection request' },
+  },
+  {
+    value: 'CONNECTION_ACCEPTED',
+    icon: 'user-check',
+    group: 'connections',
+    tone: 'success',
+    labels: { 'pt-BR': 'aceitou sua conexão', en: 'accepted your connection' },
+  },
+  {
+    value: 'FOLLOW_NEW',
+    icon: 'user-plus',
+    group: 'connections',
+    tone: 'info',
+    labels: { 'pt-BR': 'começou a seguir você', en: 'started following you' },
+  },
+  {
+    value: 'SKILL_DECAY',
+    icon: 'trending-down',
+    group: 'engagement',
+    tone: 'warning',
+    labels: {
+      'pt-BR': 'Uma das suas skills está parada — atualize para não perder relevância.',
+      en: 'One of your skills has gone stale — refresh it to stay relevant.',
+    },
+  },
+  {
+    value: 'APPLICATION_STALE',
+    icon: 'alarm-clock',
+    group: 'engagement',
+    tone: 'warning',
+    labels: {
+      'pt-BR': 'Aplicação sem resposta — vale enviar um follow-up.',
+      en: 'An application got no reply — consider sending a follow-up.',
+    },
+  },
+  {
+    value: 'CONNECTION_RECOMMENDATION',
+    icon: 'users',
+    group: 'connections',
+    tone: 'info',
+    labels: {
+      'pt-BR': 'Encontramos pessoas com skills parecidas com as suas.',
+      en: 'We found people with overlapping skills.',
+    },
+  },
+];
+
+const JOB_APPLICATION_EVENT_TYPES: EnumValueDescriptor[] = [
+  {
+    value: 'SUBMITTED',
+    icon: 'briefcase',
+    tone: 'neutral',
+    labels: { 'pt-BR': 'Enviada', en: 'Submitted' },
+  },
+  {
+    value: 'VIEWED',
+    icon: 'eye',
+    tone: 'info',
+    labels: { 'pt-BR': 'Visualizada', en: 'Viewed' },
+  },
+  {
+    value: 'INTERVIEW_SCHEDULED',
+    icon: 'calendar',
+    tone: 'info',
+    labels: { 'pt-BR': 'Entrevista marcada', en: 'Interview scheduled' },
+  },
+  {
+    value: 'INTERVIEW_COMPLETED',
+    icon: 'check-circle-2',
+    tone: 'success',
+    labels: { 'pt-BR': 'Entrevista concluída', en: 'Interview completed' },
+  },
+  {
+    value: 'OFFER_RECEIVED',
+    icon: 'check-circle-2',
+    tone: 'success',
+    labels: { 'pt-BR': 'Oferta recebida', en: 'Offer received' },
+  },
+  {
+    value: 'REJECTED',
+    icon: 'x-circle',
+    tone: 'danger',
+    labels: { 'pt-BR': 'Rejeitada', en: 'Rejected' },
+  },
+  {
+    value: 'WITHDRAWN',
+    icon: 'x-circle',
+    tone: 'neutral',
+    labels: { 'pt-BR': 'Retirada', en: 'Withdrawn' },
+  },
+  {
+    value: 'FOLLOW_UP_SENT',
+    icon: 'message-square-plus',
+    tone: 'info',
+    labels: { 'pt-BR': 'Follow-up enviado', en: 'Follow-up sent' },
+  },
+];
+
+const EMAIL_DELIVERY_MODES: EnumValueDescriptor[] = [
+  {
+    value: 'INSTANT',
+    icon: 'zap',
+    tone: 'info',
+    labels: { 'pt-BR': 'Instantâneo', en: 'Instant' },
+  },
+  {
+    value: 'DAILY',
+    icon: 'sun',
+    tone: 'neutral',
+    labels: { 'pt-BR': 'Resumo diário', en: 'Daily digest' },
+  },
+  {
+    value: 'WEEKLY',
+    icon: 'calendar-days',
+    tone: 'neutral',
+    labels: { 'pt-BR': 'Resumo semanal', en: 'Weekly digest' },
+  },
+  {
+    value: 'OFF',
+    icon: 'bell-off',
+    tone: 'neutral',
+    labels: { 'pt-BR': 'Desativado', en: 'Off' },
+  },
+];
+
+export const ENUM_CATALOG: Record<string, EnumValueDescriptor[]> = {
+  'notification-types': NOTIFICATION_TYPES,
+  'job-application-event-types': JOB_APPLICATION_EVENT_TYPES,
+  'email-delivery-modes': EMAIL_DELIVERY_MODES,
+};
+
+export function listEnumKeys(): string[] {
+  return Object.keys(ENUM_CATALOG);
+}
+
+export function getEnum(key: string): EnumDescriptor | null {
+  const values = ENUM_CATALOG[key];
+  if (!values) return null;
+  return { key, values };
+}

--- a/src/bounded-contexts/platform/ui-metadata/services/me-dashboard.service.ts
+++ b/src/bounded-contexts/platform/ui-metadata/services/me-dashboard.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/bounded-contexts/platform/prisma/prisma.service';
+
+export interface MeDashboardPayload {
+  viewer: { id: string; name: string | null; email: string | null };
+  counts: {
+    resumes: number;
+    applications: number;
+    unreadNotifications: number;
+    followers: number;
+    following: number;
+  };
+  recentNotifications: Array<{
+    id: string;
+    type: string;
+    message: string;
+    messageKey: string | null;
+    messageParams: unknown;
+    read: boolean;
+    createdAt: Date;
+  }>;
+  pendingFollowUps: number;
+}
+
+@Injectable()
+export class MeDashboardService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async load(userId: string): Promise<MeDashboardPayload> {
+    const [
+      viewer,
+      resumesCount,
+      applicationsCount,
+      unreadCount,
+      followersCount,
+      followingCount,
+      recentNotifications,
+      pendingFollowUps,
+    ] = await Promise.all([
+      this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true, name: true, email: true },
+      }),
+      this.prisma.resume.count({ where: { userId } }),
+      this.prisma.jobApplication.count({
+        where: { userId, status: { not: 'WITHDRAWN' } },
+      }),
+      this.prisma.notification.count({ where: { userId, read: false } }),
+      this.prisma.follow.count({ where: { followingId: userId } }),
+      this.prisma.follow.count({ where: { followerId: userId } }),
+      this.prisma.notification.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          type: true,
+          message: true,
+          messageKey: true,
+          messageParams: true,
+          read: true,
+          createdAt: true,
+        },
+      }),
+      this.prisma.notification.count({
+        where: { userId, type: 'APPLICATION_STALE', read: false },
+      }),
+    ]);
+
+    return {
+      viewer: viewer ?? { id: userId, name: null, email: null },
+      counts: {
+        resumes: resumesCount,
+        applications: applicationsCount,
+        unreadNotifications: unreadCount,
+        followers: followersCount,
+        following: followingCount,
+      },
+      recentNotifications,
+      pendingFollowUps,
+    };
+  }
+}

--- a/src/bounded-contexts/platform/ui-metadata/services/menu-builder.ts
+++ b/src/bounded-contexts/platform/ui-metadata/services/menu-builder.ts
@@ -1,0 +1,110 @@
+/**
+ * Permission-aware menu builder.
+ *
+ * Returns the navigation tree the current user is allowed to see, with
+ * labels already localized. UI renders <NavTree data={menu} /> and never
+ * needs to hide/show items based on roles or feature flags.
+ */
+
+import type { Permission } from '@/shared-kernel/authorization';
+import type { SupportedLocale } from './enum-catalog';
+
+export interface MenuNode {
+  id: string;
+  path: string;
+  icon: string;
+  labels: Record<SupportedLocale, string>;
+  children?: MenuNode[];
+  requires?: Permission[];
+}
+
+const TREE: MenuNode[] = [
+  {
+    id: 'dashboard',
+    path: '/dashboard',
+    icon: 'layout-dashboard',
+    labels: { 'pt-BR': 'Painel', en: 'Dashboard' },
+  },
+  {
+    id: 'cv',
+    path: '/cv',
+    icon: 'file-text',
+    labels: { 'pt-BR': 'Currículos', en: 'Resumes' },
+  },
+  {
+    id: 'jobs',
+    path: '/jobs',
+    icon: 'briefcase',
+    labels: { 'pt-BR': 'Vagas', en: 'Jobs' },
+    children: [
+      {
+        id: 'jobs.applications',
+        path: '/jobs/applications',
+        icon: 'list-checks',
+        labels: { 'pt-BR': 'Aplicações', en: 'Applications' },
+      },
+      {
+        id: 'jobs.saved',
+        path: '/jobs/saved',
+        icon: 'bookmark',
+        labels: { 'pt-BR': 'Salvas', en: 'Saved' },
+      },
+    ],
+  },
+  {
+    id: 'network',
+    path: '/mynetwork',
+    icon: 'users',
+    labels: { 'pt-BR': 'Rede', en: 'Network' },
+    children: [
+      {
+        id: 'network.suggestions',
+        path: '/mynetwork/suggestions',
+        icon: 'user-plus',
+        labels: { 'pt-BR': 'Sugestões', en: 'Suggestions' },
+      },
+    ],
+  },
+  {
+    id: 'feed',
+    path: '/feed',
+    icon: 'newspaper',
+    labels: { 'pt-BR': 'Feed', en: 'Feed' },
+  },
+  {
+    id: 'messages',
+    path: '/messages',
+    icon: 'message-square',
+    labels: { 'pt-BR': 'Mensagens', en: 'Messages' },
+  },
+  {
+    id: 'settings',
+    path: '/settings',
+    icon: 'settings',
+    labels: { 'pt-BR': 'Configurações', en: 'Settings' },
+  },
+  {
+    id: 'admin',
+    path: '/admin',
+    icon: 'shield',
+    labels: { 'pt-BR': 'Admin', en: 'Admin' },
+    requires: ['admin:full_access' as Permission],
+  },
+];
+
+function filterTree(nodes: MenuNode[], userPermissions: Set<string>): MenuNode[] {
+  const out: MenuNode[] = [];
+  for (const node of nodes) {
+    if (node.requires && !node.requires.every((p) => userPermissions.has(p))) continue;
+    const filtered: MenuNode = { ...node };
+    if (node.children) {
+      filtered.children = filterTree(node.children, userPermissions);
+    }
+    out.push(filtered);
+  }
+  return out;
+}
+
+export function buildMenu(userPermissions: string[]): MenuNode[] {
+  return filterTree(TREE, new Set(userPermissions));
+}

--- a/src/bounded-contexts/platform/ui-metadata/services/menu.service.ts
+++ b/src/bounded-contexts/platform/ui-metadata/services/menu.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/bounded-contexts/platform/prisma/prisma.service';
+import { buildMenu, type MenuNode } from './menu-builder';
+
+@Injectable()
+export class MenuService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Pull direct UserPermission grants (granted=true, not expired) for the
+   * viewer and hand them to buildMenu. Roles/groups would deserve a join
+   * too — keeping it minimal until the tree starts gating more entries.
+   */
+  async getMenuFor(userId: string): Promise<MenuNode[]> {
+    const grants = await this.prisma.userPermission.findMany({
+      where: {
+        userId,
+        granted: true,
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+      },
+      select: { permission: { select: { resource: true, action: true } } },
+    });
+
+    const out: string[] = [];
+    for (const g of grants) {
+      if (g.permission) out.push(`${g.permission.resource}:${g.permission.action}`);
+    }
+    return buildMenu(out);
+  }
+}

--- a/src/bounded-contexts/platform/ui-metadata/ui-metadata.module.ts
+++ b/src/bounded-contexts/platform/ui-metadata/ui-metadata.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@/bounded-contexts/platform/prisma/prisma.module';
+import { MeDashboardController } from './controllers/me-dashboard.controller';
+import { UiMetadataController } from './controllers/ui-metadata.controller';
+import { MeDashboardService } from './services/me-dashboard.service';
+import { MenuService } from './services/menu.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UiMetadataController, MeDashboardController],
+  providers: [MenuService, MeDashboardService],
+})
+export class UiMetadataModule {}

--- a/src/bounded-contexts/social/services/skill-decay.service.ts
+++ b/src/bounded-contexts/social/services/skill-decay.service.ts
@@ -76,6 +76,11 @@ export class SkillDecayService {
         userId: finding.userId,
         type: 'SKILL_DECAY',
         message: `Your "${finding.skillName}" skill hasn't moved in ${finding.daysSinceTouched} days — pick a small project or short course to reactivate it.`,
+        messageKey: 'notification.skill_decay',
+        messageParams: {
+          skillName: finding.skillName,
+          daysSinceTouched: finding.daysSinceTouched,
+        },
       },
     });
   }

--- a/src/shared-kernel/interceptors/human-relative.interceptor.ts
+++ b/src/shared-kernel/interceptors/human-relative.interceptor.ts
@@ -1,0 +1,113 @@
+/**
+ * Human-relative date enrichment interceptor
+ *
+ * Walks any JSON response and, for every property whose key matches the
+ * pattern `<name>At` (createdAt, updatedAt, occurredAt, expiresAt, etc.)
+ * and whose value parses as an ISO date string, adds a sibling
+ * `<name>AtRelative` field with a humanized "2h ago" / "in 5d" string.
+ *
+ * Goal: kill the dozens of `timeAgo()` helpers duplicated across the
+ * frontend. UI just renders `{x.createdAtRelative}` and never imports a
+ * date library.
+ *
+ * Reads the user's locale from the `Accept-Language` header (falls back
+ * to pt-BR), which is what we already do for content i18n.
+ */
+
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import type { Request } from 'express';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+const ISO_DATE_RX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const RELATIVE_KEY_SUFFIX = 'Relative';
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+type Locale = 'pt-BR' | 'en';
+
+function pickLocale(req: Request): Locale {
+  const raw = (req.headers['accept-language'] as string | undefined) ?? '';
+  return raw.toLowerCase().startsWith('en') ? 'en' : 'pt-BR';
+}
+
+function humanize(date: Date, now: number, locale: Locale): string {
+  const diff = date.getTime() - now;
+  const past = diff < 0;
+  const abs = Math.abs(diff);
+
+  const unit = abs >= DAY ? 'd' : abs >= HOUR ? 'h' : abs >= MINUTE ? 'm' : 's';
+  const value =
+    unit === 'd'
+      ? Math.floor(abs / DAY)
+      : unit === 'h'
+        ? Math.floor(abs / HOUR)
+        : unit === 'm'
+          ? Math.floor(abs / MINUTE)
+          : Math.floor(abs / SECOND);
+
+  if (locale === 'en') {
+    if (value === 0) return past ? 'just now' : 'in a moment';
+    return past ? `${value}${unit} ago` : `in ${value}${unit}`;
+  }
+  if (value === 0) return past ? 'agora' : 'em instantes';
+  // PT-BR: Portuguese readers get the same compact 2h/3d notation but with
+  // 'há' / 'em' prefix so it scans naturally without extra glue text.
+  return past ? `há ${value}${unit}` : `em ${value}${unit}`;
+}
+
+function enrich(value: unknown, now: number, locale: Locale, depth = 0): unknown {
+  // Guardrails: cap recursion depth to avoid pathological objects, never
+  // mutate strings/numbers/Date instances directly.
+  if (depth > 8 || value === null || value === undefined) return value;
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = enrich(value[i], now, locale, depth + 1);
+    }
+    return value;
+  }
+
+  if (typeof value !== 'object') return value;
+
+  const obj = value as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    const v = obj[key];
+
+    if (typeof v === 'string' && ISO_DATE_RX.test(v) && key.endsWith('At')) {
+      const relativeKey = `${key}${RELATIVE_KEY_SUFFIX}`;
+      if (obj[relativeKey] === undefined) {
+        const parsed = new Date(v);
+        if (!Number.isNaN(parsed.getTime())) {
+          obj[relativeKey] = humanize(parsed, now, locale);
+        }
+      }
+      continue;
+    }
+
+    if (v && typeof v === 'object') {
+      enrich(v, now, locale, depth + 1);
+    }
+  }
+
+  return obj;
+}
+
+@Injectable()
+export class HumanRelativeInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') return next.handle();
+    const req = context.switchToHttp().getRequest<Request>();
+    const locale = pickLocale(req);
+
+    return next.handle().pipe(
+      map((data) => {
+        if (!data || typeof data !== 'object') return data;
+        return enrich(data, Date.now(), locale);
+      }),
+    );
+  }
+}

--- a/src/shared-kernel/viewer-context/viewer-context.types.ts
+++ b/src/shared-kernel/viewer-context/viewer-context.types.ts
@@ -1,0 +1,15 @@
+/**
+ * Per-resource viewer permissions/state, attached as `_viewer` on every
+ * payload returned by a controller decorated with @WithViewer(builder).
+ *
+ * The shape is intentionally open so each resource can expose its own
+ * action surface (Job: canApply/alreadyApplied; ResumeShare: canEdit/
+ * hasPassword; etc.). Consumers in the UI just check for the keys they
+ * need — no global enum to maintain.
+ */
+export type ViewerContext = Record<string, unknown>;
+
+export interface WithViewer<T> {
+  data: T;
+  _viewer: ViewerContext;
+}

--- a/swagger-generation-report.json
+++ b/swagger-generation-report.json
@@ -1,8 +1,8 @@
 {
   "success": true,
   "generatedBy": "nest-swagger",
-  "paths": 317,
-  "operations": 380,
+  "paths": 323,
+  "operations": 387,
   "schemas": 267,
   "tags": [
     "auth",

--- a/swagger-generation-report.json
+++ b/swagger-generation-report.json
@@ -1,8 +1,8 @@
 {
   "success": true,
   "generatedBy": "nest-swagger",
-  "paths": 316,
-  "operations": 379,
+  "paths": 317,
+  "operations": 380,
   "schemas": 267,
   "tags": [
     "auth",

--- a/swagger.json
+++ b/swagger.json
@@ -4720,6 +4720,82 @@
         ]
       }
     },
+    "/api/v1/me/ui-state": {
+      "get": {
+        "operationId": "users_getAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Returns every UI-state row for the current user. UI bootstraps once and reads keys locally.",
+        "tags": [
+          "users"
+        ]
+      }
+    },
+    "/api/v1/me/ui-state/{key}": {
+      "patch": {
+        "operationId": "users_setKey",
+        "parameters": [
+          {
+            "name": "key",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Upsert a single UI-state key/value (idempotent).",
+        "tags": [
+          "users"
+        ]
+      },
+      "delete": {
+        "operationId": "users_deleteKey",
+        "parameters": [
+          {
+            "name": "key",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Remove a UI-state key.",
+        "tags": [
+          "users"
+        ]
+      }
+    },
     "/api/v1/users/{username}/profile": {
       "get": {
         "operationId": "users_getPublicProfileByUsername",
@@ -20531,6 +20607,95 @@
         "summary": "List recent delivery attempts for a webhook.",
         "tags": [
           "Webhooks"
+        ]
+      }
+    },
+    "/api/v1/enums": {
+      "get": {
+        "operationId": "uiMetadata_listEnums",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "List all enum keys exposed by the catalog.",
+        "tags": [
+          "ui-metadata"
+        ]
+      }
+    },
+    "/api/v1/enums/{key}": {
+      "get": {
+        "operationId": "uiMetadata_getEnumByKey",
+        "parameters": [
+          {
+            "name": "key",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Full descriptor for a UI enum (notification-types, job-application-event-types, etc.) with localized labels + icon hints.",
+        "tags": [
+          "ui-metadata"
+        ]
+      }
+    },
+    "/api/v1/me/menu": {
+      "get": {
+        "operationId": "uiMetadata_getMenu",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Permission-aware navigation tree for the current user with labels in the request locale.",
+        "tags": [
+          "ui-metadata"
+        ]
+      }
+    },
+    "/api/v1/pages/me-dashboard": {
+      "get": {
+        "operationId": "pages_load",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          }
+        ],
+        "summary": "Single payload for the dashboard: counts (resumes, applications, unread notifications), latest activity items, viewer summary. Replaces ~5 parallel UI fetches.",
+        "tags": [
+          "pages"
         ]
       }
     }

--- a/swagger.json
+++ b/swagger.json
@@ -12877,7 +12877,42 @@
             "bearer": []
           }
         ],
-        "summary": "Run a resume AST through the ATS parser simulator and return the extracted text + warnings.",
+        "summary": "Run an explicit AtsSimulationInput payload through the simulator. Use this when the caller has already shaped the AST.",
+        "tags": [
+          "ats"
+        ]
+      }
+    },
+    "/api/v1/ats/simulate/{resumeId}": {
+      "get": {
+        "operationId": "ats_simulateForResume",
+        "parameters": [
+          {
+            "name": "resumeId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Requires permission: resume:read"
+          }
+        },
+        "security": [
+          {
+            "JWT-auth": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Convenience endpoint: load a resume by id, map it to AtsSimulationInput, and run the simulator in one call.",
         "tags": [
           "ats"
         ]


### PR DESCRIPTION
## What

A batch of backend primitives that let \`patch-careers-ui\` shed code and stay generic: each one replaces a chunk of duplicated UI logic.

| # | Feature | Replaces in UI |
|---|---|---|
| 1 | Composite \`/pages/me-dashboard\` | 5 parallel fetches + merge in dashboard |
| 2 | \`HumanRelativeInterceptor\` (auto \`<key>AtRelative\`) | Every \`timeAgo()\` helper duplicated across 5+ files |
| 3 | \`Notification.messageKey\` + \`messageParams\` | i18n switch-cases in \`/activity\` and \`summarize()\` |
| 4 | \`/enums/:key\` (notification-types, event-types, delivery-modes) | Hardcoded TS unions + \`EVENT_LABEL\` + \`iconFor()\` maps |
| 5 | (groundwork) \`ViewerContext\` types under \`shared-kernel\` | Pattern for per-resource \`_viewer\` injection |
| 7 | (deferred — see notes) | Onboarding state machine — too large for this batch |
| 8 | \`UserUiState\` + \`/me/ui-state\` | localStorage / sessionStorage / URL searchParam |
| 10 | \`/me/menu\` permission-aware nav | Hardcoded role checks + duplicated menus across header/sidebar/mobile |
| 11 | \`error: { userMessage, action, ... }\` envelope | ~30 try/catch + toastState + goto blocks |

Plus #3 + #2 ripple: AntiGhosting + SkillDecay now write structured \`messageKey\`/\`messageParams\` so the bell renders the same notification in any locale.

## Migrations

\`20260419230432_server_driven_ui\` — Notification.messageKey/Params, UserUiState table.

## Pre-commit

Swagger + typecheck + lint + 2876 unit tests + arch + contract — all green.

## Not included

- **#6 Form schema endpoints**: too large to ship without a UI consumer ready.
- **#7 Onboarding state machine**: needs a refactor of multiple \`/onboarding/*\` routes; deserves its own PR.
- **#9 Action bundles**: case-by-case; will follow as concrete pages need them.