### PR TITLE
fix(backend): backend audit hardening — 30 fixes (critical → polish)

### DIFF
--- a/.attestation
+++ b/.attestation
@@ -1,6 +1,6 @@
 {
   "version": "3",
-  "tree_hash": "36606a27441347be3aee29fb265ca9a67726ff45",
+  "tree_hash": "8a941af13b20bdee0f665683b5ae8762942a2710",
   "checks": "swagger typecheck lint unit arch contract",
   "metrics": {
     "typecheck": {
@@ -9,30 +9,30 @@
     },
     "lint": {
       "status": "ok",
-      "time_ms": 1348
+      "time_ms": 1266
     },
     "unit": {
       "status": "ok",
-      "time_ms": 6560,
+      "time_ms": 6395,
       "passed": 2876,
       "failed": 0,
       "skipped": 0
     },
     "arch": {
       "status": "ok",
-      "time_ms": 1736,
+      "time_ms": 1935,
       "passed": 42,
       "failed": 0,
       "skipped": 1
     },
     "contract": {
       "status": "ok",
-      "time_ms": 841,
+      "time_ms": 771,
       "passed": 42,
       "failed": 0,
       "skipped": 0
     }
   },
-  "timestamp": "2026-04-20T00:56:03Z",
+  "timestamp": "2026-04-20T03:10:46Z",
   "git_user": "enzo.patti@aluno.senai.br"
 }

--- a/client-swagger.json
+++ b/client-swagger.json
@@ -9439,8 +9439,51 @@
         "operationId": "search_search",
         "parameters": [
           {
-            "name": "q",
-            "required": true,
+            "name": "sortBy",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "enum": ["relevance", "date", "views"],
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Default 20, max 100",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Default 1, max 1000",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "maxExp",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "minExp",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "location",
+            "required": false,
             "in": "query",
             "schema": {
               "type": "string"
@@ -9448,56 +9491,18 @@
           },
           {
             "name": "skills",
-            "required": true,
+            "required": false,
             "in": "query",
+            "description": "Comma-separated",
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "location",
-            "required": true,
+            "name": "q",
+            "required": false,
             "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "minExp",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "maxExp",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "sortBy",
-            "required": true,
-            "in": "query",
+            "description": "Free-text query (max 500)",
             "schema": {
               "type": "string"
             }
@@ -9524,17 +9529,19 @@
         "operationId": "search_suggestions",
         "parameters": [
           {
-            "name": "prefix",
-            "required": true,
+            "name": "limit",
+            "required": false,
             "in": "query",
+            "description": "Default 10, max 50",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           },
           {
-            "name": "limit",
-            "required": true,
+            "name": "prefix",
+            "required": false,
             "in": "query",
+            "description": "Max 50 chars",
             "schema": {
               "type": "string"
             }
@@ -9570,10 +9577,11 @@
           },
           {
             "name": "limit",
-            "required": true,
+            "required": false,
             "in": "query",
+            "description": "Default 5, max 50",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -12757,60 +12765,24 @@
         "operationId": "jobs_findAll",
         "parameters": [
           {
-            "name": "page",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "search",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "skills",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "paymentCurrency",
+            "name": "minEnglishLevel",
             "required": false,
             "in": "query",
-            "description": "CSV of BRL|USD|EUR|GBP",
-            "schema": {
-              "type": "string"
-            }
+            "description": "Max level the viewer accepts. Returns jobs whose required level is ≤ this (or null).",
+            "schema": {}
           },
           {
             "name": "remotePolicy",
             "required": false,
             "in": "query",
             "description": "CSV of REMOTE|HYBRID|ONSITE",
-            "schema": {
-              "type": "string"
-            }
+            "schema": {}
           },
           {
-            "name": "minEnglishLevel",
+            "name": "paymentCurrency",
             "required": false,
             "in": "query",
-            "description": "Max level the viewer accepts. Returns jobs whose required level is ≤ this (or null).",
+            "description": "CSV of BRL|USD|EUR|GBP",
             "schema": {}
           }
         ],
@@ -12857,56 +12829,7 @@
     "/api/v1/jobs/with-fit-score": {
       "get": {
         "operationId": "jobs_findAllWithFitScore",
-        "parameters": [
-          {
-            "name": "page",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "search",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "skills",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "paymentCurrency",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "remotePolicy",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "401": {
             "description": "Authentication required"
@@ -12930,24 +12853,7 @@
     "/api/v1/jobs/mine": {
       "get": {
         "operationId": "jobs_getMyJobs",
-        "parameters": [
-          {
-            "name": "page",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "401": {
             "description": "Authentication required"
@@ -12972,7 +12878,7 @@
         "operationId": "jobs_getBookmarkedJobs",
         "parameters": [
           {
-            "name": "page",
+            "name": "limit",
             "required": false,
             "in": "query",
             "schema": {
@@ -12980,7 +12886,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "page",
             "required": false,
             "in": "query",
             "schema": {
@@ -13013,7 +12919,7 @@
         "operationId": "jobs_getRecommendedJobs",
         "parameters": [
           {
-            "name": "page",
+            "name": "limit",
             "required": false,
             "in": "query",
             "schema": {
@@ -13021,7 +12927,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "page",
             "required": false,
             "in": "query",
             "schema": {
@@ -13054,7 +12960,7 @@
         "operationId": "jobs_getMyApplications",
         "parameters": [
           {
-            "name": "page",
+            "name": "limit",
             "required": false,
             "in": "query",
             "schema": {
@@ -13062,7 +12968,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "page",
             "required": false,
             "in": "query",
             "schema": {
@@ -13459,7 +13365,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "This week's curated batch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentBatchDataDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13486,7 +13399,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Application created or already existed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApproveResultDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13513,7 +13433,14 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Item marked as rejected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RejectResultDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13530,11 +13457,15 @@
         "operationId": "automation_run",
         "parameters": [],
         "responses": {
-          "401": {
-            "description": "Authentication required"
-          },
-          "403": {
-            "description": "Requires permission: feed:use"
+          "200": {
+            "description": "Batch apply summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RageApplyResultDto"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -25250,6 +25181,83 @@
           }
         },
         "required": ["type"]
+      },
+      "CurrentBatchDataDto": {
+        "type": "object",
+        "properties": {
+          "batch": {
+            "type": "object",
+            "nullable": true,
+            "description": "This week's batch or null if none active"
+          }
+        },
+        "required": ["batch"]
+      },
+      "ApproveResultDto": {
+        "type": "object",
+        "properties": {
+          "applicationId": {
+            "type": "string",
+            "example": "app_abc123"
+          },
+          "alreadyApplied": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": ["applicationId", "alreadyApplied"]
+      },
+      "RejectResultDto": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "example": "item_abc123"
+          }
+        },
+        "required": ["itemId"]
+      },
+      "RageApplyFailureDto": {
+        "type": "object",
+        "properties": {
+          "jobId": {
+            "type": "string",
+            "example": "job_abc123"
+          },
+          "reason": {
+            "type": "string",
+            "example": "Tailor service timeout"
+          }
+        },
+        "required": ["jobId", "reason"]
+      },
+      "RageApplyResultDto": {
+        "type": "object",
+        "properties": {
+          "attempted": {
+            "type": "number",
+            "example": 18,
+            "description": "How many jobs we tried to apply to"
+          },
+          "submitted": {
+            "type": "number",
+            "example": 12,
+            "description": "Successful submissions"
+          },
+          "skippedExisting": {
+            "type": "number",
+            "example": 4,
+            "description": "Skipped because user already applied"
+          },
+          "failed": {
+            "description": "Per-job failures with reason",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RageApplyFailureDto"
+            }
+          }
+        },
+        "required": ["attempted", "submitted", "skippedExisting", "failed"]
       },
       "CreateSuccessStoryDto": {
         "type": "object",

--- a/src/bounded-contexts/analytics/search/application/use-cases/search-resumes/search-resumes.use-case.ts
+++ b/src/bounded-contexts/analytics/search/application/use-cases/search-resumes/search-resumes.use-case.ts
@@ -129,18 +129,17 @@ export class SearchResumesUseCase {
   async findSimilar(resumeId: string, limit = 5): Promise<SearchResultItem[]> {
     const sourceResume = await this.prisma.resume.findUnique({
       where: { id: resumeId },
-      include: {
+      select: {
+        id: true,
         resumeSections: {
           where: {
             sectionType: {
               semanticKind: { contains: 'SKILL', mode: 'insensitive' },
             },
           },
-          include: {
+          select: {
             items: {
-              select: {
-                content: true,
-              },
+              select: { content: true },
             },
           },
         },
@@ -178,11 +177,9 @@ export class SearchResumesUseCase {
               semanticKind: { contains: 'SKILL', mode: 'insensitive' },
             },
           },
-          include: {
+          select: {
             items: {
-              select: {
-                content: true,
-              },
+              select: { content: true },
             },
           },
         },

--- a/src/bounded-contexts/analytics/search/search.controller.spec.ts
+++ b/src/bounded-contexts/analytics/search/search.controller.spec.ts
@@ -46,7 +46,7 @@ describe('SearchController', () => {
 
   describe('search', () => {
     it('should search resumes with query', async () => {
-      const result = await controller.search('developer');
+      const result = await controller.search({ q: 'developer', page: 1, limit: 20 });
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
@@ -54,21 +54,18 @@ describe('SearchController', () => {
     });
 
     it('should parse skills from comma-separated string', async () => {
-      const result = await controller.search('', 'react,typescript');
+      const result = await controller.search({
+        q: '',
+        skills: 'react,typescript',
+        page: 1,
+        limit: 20,
+      });
 
       expect(result.data?.data).toHaveLength(2); // Both have React
     });
 
     it('should parse pagination params', async () => {
-      const result = await controller.search(
-        '',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        '1',
-        '1',
-      );
+      const result = await controller.search({ q: '', page: 1, limit: 1 });
 
       expect(result.data?.page).toBe(1);
       expect(result.data?.limit).toBe(1);
@@ -76,7 +73,7 @@ describe('SearchController', () => {
     });
 
     it('should filter by location', async () => {
-      const result = await controller.search('', undefined, 'São Paulo');
+      const result = await controller.search({ q: '', location: 'São Paulo', page: 1, limit: 20 });
 
       expect(result.data?.data).toHaveLength(1);
       expect(result.data?.data[0].fullName).toBe('John Doe');
@@ -85,7 +82,7 @@ describe('SearchController', () => {
 
   describe('suggestions', () => {
     it('should return suggestions for prefix', async () => {
-      const result = await controller.suggestions('dev');
+      const result = await controller.suggestions({ prefix: 'dev', limit: 10 });
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
@@ -94,7 +91,7 @@ describe('SearchController', () => {
     });
 
     it('should respect limit parameter', async () => {
-      const result = await controller.suggestions('dev', '1');
+      const result = await controller.suggestions({ prefix: 'dev', limit: 1 });
 
       expect(result.data?.suggestions).toHaveLength(1);
     });
@@ -102,7 +99,7 @@ describe('SearchController', () => {
 
   describe('similar', () => {
     it('should find similar resumes', async () => {
-      const result = await controller.similar('resume-1');
+      const result = await controller.similar('resume-1', { limit: 5 });
 
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
@@ -118,7 +115,7 @@ describe('SearchController', () => {
         skills: ['TypeScript', 'React', 'Node.js'],
       });
 
-      const result = await controller.similar('resume-1', '1');
+      const result = await controller.similar('resume-1', { limit: 1 });
 
       expect(result.data?.resumes).toHaveLength(1);
     });

--- a/src/bounded-contexts/analytics/search/search.controller.ts
+++ b/src/bounded-contexts/analytics/search/search.controller.ts
@@ -10,14 +10,37 @@
  */
 
 import { Controller, Get, Inject, Param, Query } from '@nestjs/common';
-import { ApiOperation, ApiProperty, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiProperty, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { z } from 'zod';
 import { Public } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
 import { ApiDataResponse } from '@/bounded-contexts/platform/common/decorators/api-data-response.decorator';
 import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
 import type { DataResponse } from '@/bounded-contexts/platform/common/dto/api-response.dto';
+import { createZodPipe } from '@/bounded-contexts/platform/common/validation/zod-validation.pipe';
 import { SEARCH_SERVICE_PORT, type SearchServicePort } from './ports';
 import type { SearchParams } from './resume-search.service';
 import { parseCsvQuery } from './search.presenter';
+
+const SearchQuerySchema = z.object({
+  q: z.string().max(500).optional(),
+  skills: z.string().max(500).optional(),
+  location: z.string().max(200).optional(),
+  minExp: z.coerce.number().int().min(0).max(80).optional(),
+  maxExp: z.coerce.number().int().min(0).max(80).optional(),
+  page: z.coerce.number().int().min(1).max(1000).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  sortBy: z.enum(['relevance', 'date', 'views']).optional(),
+});
+
+const SuggestionsQuerySchema = z.object({
+  prefix: z.string().max(50).optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+const SimilarQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(5),
+});
 
 /** DTO for search result item */
 export class SearchResultItemDto {
@@ -92,6 +115,7 @@ export class SimilarResumesResponseDto {
 })
 @ApiTags('search')
 @Controller('search')
+@Throttle({ default: { limit: 30, ttl: 60_000 } })
 export class SearchController {
   constructor(
     @Inject(SEARCH_SERVICE_PORT)
@@ -104,28 +128,29 @@ export class SearchController {
   @Public()
   @Get()
   @ApiOperation({ summary: 'Search public resumes' })
+  @ApiQuery({ name: 'q', required: false, type: String, description: 'Free-text query (max 500)' })
+  @ApiQuery({ name: 'skills', required: false, type: String, description: 'Comma-separated' })
+  @ApiQuery({ name: 'location', required: false, type: String })
+  @ApiQuery({ name: 'minExp', required: false, type: Number })
+  @ApiQuery({ name: 'maxExp', required: false, type: Number })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Default 1, max 1000' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Default 20, max 100' })
+  @ApiQuery({ name: 'sortBy', required: false, enum: ['relevance', 'date', 'views'] })
   @ApiDataResponse(SearchResultsResponseDto, {
     description: 'Search results returned',
   })
   async search(
-    @Query('q') query: string,
-    @Query('skills') skills?: string,
-    @Query('location') location?: string,
-    @Query('minExp') minExp?: string,
-    @Query('maxExp') maxExp?: string,
-    @Query('page') page?: string,
-    @Query('limit') limit?: string,
-    @Query('sortBy') sortBy?: 'relevance' | 'date' | 'views',
+    @Query(createZodPipe(SearchQuerySchema)) q: z.infer<typeof SearchQuerySchema>,
   ): Promise<DataResponse<SearchResultsResponseDto>> {
     const params: SearchParams = {
-      query: query || '',
-      skills: parseCsvQuery(skills),
-      location,
-      minExperienceYears: minExp ? parseInt(minExp, 10) : undefined,
-      maxExperienceYears: maxExp ? parseInt(maxExp, 10) : undefined,
-      page: page ? parseInt(page, 10) : 1,
-      limit: limit ? parseInt(limit, 10) : 20,
-      sortBy: sortBy,
+      query: q.q || '',
+      skills: parseCsvQuery(q.skills),
+      location: q.location,
+      minExperienceYears: q.minExp,
+      maxExperienceYears: q.maxExp,
+      page: q.page,
+      limit: q.limit,
+      sortBy: q.sortBy,
     };
 
     const result = await this.searchService.search(params);
@@ -138,18 +163,15 @@ export class SearchController {
   @Public()
   @Get('suggestions')
   @ApiOperation({ summary: 'Get search autocomplete suggestions' })
+  @ApiQuery({ name: 'prefix', required: false, type: String, description: 'Max 50 chars' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Default 10, max 50' })
   @ApiDataResponse(SearchSuggestionsResponseDto, {
     description: 'Suggestions returned',
   })
   async suggestions(
-    @Query('prefix') prefix: string,
-    @Query('limit') limit?: string,
+    @Query(createZodPipe(SuggestionsQuerySchema)) q: z.infer<typeof SuggestionsQuerySchema>,
   ): Promise<DataResponse<SearchSuggestionsResponseDto>> {
-    const suggestions = await this.searchService.suggest(
-      prefix || '',
-      limit ? parseInt(limit, 10) : 10,
-    );
-
+    const suggestions = await this.searchService.suggest(q.prefix || '', q.limit);
     return { success: true, data: { suggestions } };
   }
 
@@ -159,15 +181,15 @@ export class SearchController {
   @Public()
   @Get('similar/:id')
   @ApiOperation({ summary: 'Find similar resumes by resume id' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Default 5, max 50' })
   @ApiDataResponse(SimilarResumesResponseDto, {
     description: 'Similar resumes returned',
   })
   async similar(
     @Param('id') id: string,
-    @Query('limit') limit?: string,
+    @Query(createZodPipe(SimilarQuerySchema)) q: z.infer<typeof SimilarQuerySchema>,
   ): Promise<DataResponse<SimilarResumesResponseDto>> {
-    const resumes = await this.searchService.findSimilar(id, limit ? parseInt(limit, 10) : 5);
-
+    const resumes = await this.searchService.findSimilar(id, q.limit);
     return { success: true, data: { resumes } };
   }
 }

--- a/src/bounded-contexts/automation/controllers/apply-mode.controller.ts
+++ b/src/bounded-contexts/automation/controllers/apply-mode.controller.ts
@@ -1,13 +1,30 @@
 import { Controller, Get, HttpCode, HttpStatus, Param, Post, Req, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
-import type { Request } from 'express';
-import { JwtAuthGuard } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiProperty, ApiTags } from '@nestjs/swagger';
+import {
+  type AuthenticatedRequest,
+  JwtAuthGuard,
+} from '@/bounded-contexts/identity/shared-kernel/infrastructure';
+import { ApiDataResponse } from '@/bounded-contexts/platform/common/decorators/api-data-response.decorator';
 import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
 import type { DataResponse } from '@/bounded-contexts/platform/common/dto/api-response.dto';
 import { ApplyModeService, type WeeklyCuratedBatchView } from '../services/apply-mode.service';
 
-interface RequestWithUser extends Request {
-  user: { userId: string; email: string };
+class CurrentBatchDataDto {
+  @ApiProperty({ nullable: true, description: "This week's batch or null if none active" })
+  batch!: WeeklyCuratedBatchView | null;
+}
+
+class ApproveResultDto {
+  @ApiProperty({ example: 'app_abc123' })
+  applicationId!: string;
+
+  @ApiProperty({ example: false })
+  alreadyApplied!: boolean;
+}
+
+class RejectResultDto {
+  @ApiProperty({ example: 'item_abc123' })
+  itemId!: string;
 }
 
 @SdkExport({ tag: 'apply-mode', description: 'Weekly curated approval flow' })
@@ -21,9 +38,8 @@ export class ApplyModeController {
   @Get('weekly-curated/current')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: "This week's curated batch for the viewer." })
-  async current(
-    @Req() req: RequestWithUser,
-  ): Promise<DataResponse<{ batch: WeeklyCuratedBatchView | null }>> {
+  @ApiDataResponse(CurrentBatchDataDto, { description: "This week's curated batch" })
+  async current(@Req() req: AuthenticatedRequest): Promise<DataResponse<CurrentBatchDataDto>> {
     const batch = await this.service.getCurrentBatch(req.user.userId);
     return { success: true, data: { batch } };
   }
@@ -34,10 +50,11 @@ export class ApplyModeController {
     summary: "Approve a curated item — submits a JobApplication using the user's primary resume.",
   })
   @ApiParam({ name: 'itemId', type: 'string' })
+  @ApiDataResponse(ApproveResultDto, { description: 'Application created or already existed' })
   async approve(
     @Param('itemId') itemId: string,
-    @Req() req: RequestWithUser,
-  ): Promise<DataResponse<{ applicationId: string; alreadyApplied: boolean }>> {
+    @Req() req: AuthenticatedRequest,
+  ): Promise<DataResponse<ApproveResultDto>> {
     const result = await this.service.approve(req.user.userId, itemId);
     return { success: true, data: result };
   }
@@ -46,10 +63,11 @@ export class ApplyModeController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Reject a curated item.' })
   @ApiParam({ name: 'itemId', type: 'string' })
+  @ApiDataResponse(RejectResultDto, { description: 'Item marked as rejected' })
   async reject(
     @Param('itemId') itemId: string,
-    @Req() req: RequestWithUser,
-  ): Promise<DataResponse<{ itemId: string }>> {
+    @Req() req: AuthenticatedRequest,
+  ): Promise<DataResponse<RejectResultDto>> {
     await this.service.reject(req.user.userId, itemId);
     return { success: true, data: { itemId } };
   }

--- a/src/bounded-contexts/automation/controllers/rage-apply.controller.ts
+++ b/src/bounded-contexts/automation/controllers/rage-apply.controller.ts
@@ -1,15 +1,41 @@
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiProperty, ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
 import type { UserPayload } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
+import { ApiDataResponse } from '@/bounded-contexts/platform/common/decorators/api-data-response.decorator';
 import { CurrentUser } from '@/bounded-contexts/platform/common/decorators/current-user.decorator';
 import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
+import type { DataResponse } from '@/bounded-contexts/platform/common/dto/api-response.dto';
+import { createZodPipe } from '@/bounded-contexts/platform/common/validation/zod-validation.pipe';
 import { Permission, RequirePermission } from '@/shared-kernel/authorization';
 import { RageApplyService } from '../services/rage-apply.service';
 
-interface RageApplyBody {
-  minFit?: number;
-  maxApplications?: number;
-  sinceDays?: number;
+const RageApplyBodySchema = z.object({
+  minFit: z.coerce.number().int().min(0).max(100).optional(),
+  maxApplications: z.coerce.number().int().min(1).max(100).optional(),
+  sinceDays: z.coerce.number().int().min(1).max(90).optional(),
+});
+
+class RageApplyFailureDto {
+  @ApiProperty({ example: 'job_abc123' })
+  jobId!: string;
+
+  @ApiProperty({ example: 'Tailor service timeout' })
+  reason!: string;
+}
+
+class RageApplyResultDto {
+  @ApiProperty({ example: 18, description: 'How many jobs we tried to apply to' })
+  attempted!: number;
+
+  @ApiProperty({ example: 12, description: 'Successful submissions' })
+  submitted!: number;
+
+  @ApiProperty({ example: 4, description: 'Skipped because user already applied' })
+  skippedExisting!: number;
+
+  @ApiProperty({ type: [RageApplyFailureDto], description: 'Per-job failures with reason' })
+  failed!: RageApplyFailureDto[];
 }
 
 @SdkExport({ tag: 'automation', description: 'Batch apply API' })
@@ -26,10 +52,11 @@ export class RageApplyController {
     summary:
       'Submit tailored applications to every open job that matches minFit. Bounded by maxApplications (default 20, cap 100).',
   })
+  @ApiDataResponse(RageApplyResultDto, { description: 'Batch apply summary' })
   async run(
     @CurrentUser() user: UserPayload,
-    @Body() body: RageApplyBody = {},
-  ): Promise<{ success: true; data: unknown }> {
+    @Body(createZodPipe(RageApplyBodySchema)) body: z.infer<typeof RageApplyBodySchema>,
+  ): Promise<DataResponse<RageApplyResultDto>> {
     const since =
       typeof body.sinceDays === 'number'
         ? new Date(Date.now() - body.sinceDays * 24 * 60 * 60 * 1000)

--- a/src/bounded-contexts/automation/services/curated-selector.service.ts
+++ b/src/bounded-contexts/automation/services/curated-selector.service.ts
@@ -82,7 +82,9 @@ export class CuratedSelectorService {
     });
 
     const scored: Array<{ jobId: string; matchScore: number }> = [];
-    for (const job of candidates) {
+    let scoringFailures = 0;
+    const jobs = candidates;
+    for (const job of jobs) {
       const jobText = [
         job.title,
         (job.requirements ?? []).join('\n'),
@@ -102,10 +104,22 @@ export class CuratedSelectorService {
           scored.push({ jobId: job.id, matchScore: match.matchScore });
         }
       } catch (err) {
+        scoringFailures++;
         this.logger.warn(
           `Scoring failed for user=${userId} job=${job.id}: ${(err as Error).message}`,
         );
       }
+    }
+
+    if (scoringFailures > 0 && scoringFailures === jobs.length) {
+      throw new Error(
+        `Curated selector: all ${jobs.length} scoring calls failed for user=${userId} — likely a downstream outage`,
+      );
+    }
+    if (scoringFailures > jobs.length / 2) {
+      this.logger.error(
+        `Curated selector: ${scoringFailures}/${jobs.length} scoring calls failed for user=${userId} — investigate`,
+      );
     }
 
     scored.sort((a, b) => b.matchScore - a.matchScore);

--- a/src/bounded-contexts/automation/services/rage-apply.service.ts
+++ b/src/bounded-contexts/automation/services/rage-apply.service.ts
@@ -46,11 +46,15 @@ export class RageApplyService {
     const user = await this.prisma.user.findUnique({
       where: { id: input.userId },
       select: {
+        isActive: true,
         primaryResumeId: true,
         preferences: { select: { applyCriteria: true } },
       },
     });
-    if (!user?.primaryResumeId) {
+    if (!user?.isActive) {
+      throw new EntityNotFoundException('User', input.userId);
+    }
+    if (!user.primaryResumeId) {
       throw new EntityNotFoundException('Resume', 'primary');
     }
 

--- a/src/bounded-contexts/automation/workers/auto-apply.worker.ts
+++ b/src/bounded-contexts/automation/workers/auto-apply.worker.ts
@@ -59,9 +59,13 @@ export class AutoApplyWorker extends WorkerHost implements OnModuleInit {
       select: { id: true },
     });
     this.logger.log(`Enqueueing auto-apply for ${users.length} users`);
-    for (const u of users) {
-      await this.queue.add('auto-apply-run', { kind: 'run-for-user', userId: u.id });
-    }
+    if (users.length === 0) return;
+    await this.queue.addBulk(
+      users.map((u) => ({
+        name: 'auto-apply-run',
+        data: { kind: 'run-for-user' as const, userId: u.id },
+      })),
+    );
   }
 
   private async runForUser(userId: string): Promise<void> {
@@ -98,42 +102,50 @@ export class AutoApplyWorker extends WorkerHost implements OnModuleInit {
     if (picks.length === 0) return;
 
     let submitted = 0;
+    const failures: Array<{ jobId: string; reason: string }> = [];
+    const primaryResumeId = user.primaryResumeId;
     for (const pick of picks) {
       try {
-        // Idempotent — the unique (jobId, userId) constraint protects us;
-        // skip early so we don't pay the LLM cost for a re-application.
         const existing = await this.prisma.jobApplication.findUnique({
           where: { jobId_userId: { jobId: pick.jobId, userId } },
         });
         if (existing) continue;
 
-        // Generate a tailored variant first so the CV + cover letter reflect
-        // the specific job. The returned versionId is linked on the
-        // JobApplication so the tracker + analytics can show "applied with
-        // tailored variant" and measure tailoring ROI.
         const tailored = await this.tailor.tailorForJob({
-          resumeId: user.primaryResumeId,
+          resumeId: primaryResumeId,
           userId,
           jobId: pick.jobId,
         });
 
-        await this.prisma.jobApplication.create({
-          data: {
-            jobId: pick.jobId,
-            userId,
-            resumeId: user.primaryResumeId,
-            tailoredVersionId: tailored.versionId,
-            coverLetter: tailored.summary ?? user.preferences?.applyCriteria?.defaultCover ?? null,
-          },
+        await this.prisma.$transaction(async (tx) => {
+          const raceCheck = await tx.jobApplication.findUnique({
+            where: { jobId_userId: { jobId: pick.jobId, userId } },
+          });
+          if (raceCheck) return;
+          await tx.jobApplication.create({
+            data: {
+              jobId: pick.jobId,
+              userId,
+              resumeId: primaryResumeId,
+              tailoredVersionId: tailored.versionId,
+              coverLetter:
+                tailored.summary ?? user.preferences?.applyCriteria?.defaultCover ?? null,
+            },
+          });
         });
         submitted++;
       } catch (err) {
-        this.logger.warn(
-          `Auto-apply for user=${userId} job=${pick.jobId} failed: ${(err as Error).message}`,
-        );
+        const reason = (err as Error).message;
+        failures.push({ jobId: pick.jobId, reason });
+        this.logger.error(`Auto-apply user=${userId} job=${pick.jobId} failed: ${reason}`);
       }
     }
     this.logger.log(`Auto-apply: user=${userId} submitted=${submitted} (of ${picks.length})`);
+    if (failures.length === picks.length && picks.length > 0) {
+      throw new Error(
+        `Auto-apply user=${userId} all ${picks.length} picks failed; first reason: ${failures[0].reason}`,
+      );
+    }
   }
 
   @OnWorkerEvent('failed')

--- a/src/bounded-contexts/export/infrastructure/adapters/typst-wasm/typst-wasm-pdf-renderer.adapter.ts
+++ b/src/bounded-contexts/export/infrastructure/adapters/typst-wasm/typst-wasm-pdf-renderer.adapter.ts
@@ -7,14 +7,9 @@ import {
 @Injectable()
 export class TypstWasmPdfRendererAdapter extends PdfRendererPort {
   async render(astJson: string, options?: PdfRenderOptions): Promise<Buffer> {
-    // TODO: Replace with actual Typst WASM binding
-    // Expected integration: @aspect-build/typst-ts-wasm or similar
-    //
-    // Implementation steps:
-    // 1. Write astJson to a virtual filesystem as "data.json"
-    // 2. Load the Typst template from templates-v2/resume.typ
-    // 3. Compile via WASM: typst.compile(mainFile, virtualFs) -> Uint8Array
-    // 4. Return Buffer.from(result)
+    // Stub adapter: kept in place so the DI container can wire a Typst WASM
+    // path once a real binding lands (e.g. @aspect-build/typst-ts-wasm).
+    // Until then, callers must use TypstCompilerService instead.
     void astJson;
     void options;
 

--- a/src/bounded-contexts/export/infrastructure/controllers/export-pdf.controller.ts
+++ b/src/bounded-contexts/export/infrastructure/controllers/export-pdf.controller.ts
@@ -28,35 +28,7 @@ import { AppLoggerService } from '@/bounded-contexts/platform/common/logger/logg
 import { Permission, RequirePermission } from '@/shared-kernel/authorization';
 import { EXPORT_USE_CASES, type ExportUseCases } from '../../application/ports/export.port';
 import { ExportCompletedEvent, ExportFailedEvent, ExportRequestedEvent } from '../../domain/events';
-
-/**
- * Sanitizes query parameters to prevent path traversal attacks.
- * Only allows alphanumeric characters, hyphens, underscores, and spaces.
- * Returns undefined if input contains dangerous characters.
- */
-function sanitizeQueryParam(input: string | undefined): string | undefined {
-  if (!input) return undefined;
-
-  // Detect path traversal attempts
-  if (input.includes('..') || input.includes('/') || input.includes('\\')) {
-    return undefined;
-  }
-
-  // Detect shell injection attempts
-  if (/[;|`$(){}]/.test(input)) {
-    return undefined;
-  }
-
-  // Only allow safe characters: alphanumeric, hyphens, underscores, spaces
-  const sanitized = input.replace(/[^a-zA-Z0-9\-_ ]/g, '');
-
-  // If sanitization changed the input significantly, reject it
-  if (sanitized.length < input.length * 0.8) {
-    return undefined;
-  }
-
-  return sanitized || undefined;
-}
+import { sanitizeQueryParam } from '../helpers';
 
 @SdkExport({ tag: 'export', description: 'Export API' })
 @ApiTags('export')

--- a/src/bounded-contexts/export/infrastructure/helpers/index.ts
+++ b/src/bounded-contexts/export/infrastructure/helpers/index.ts
@@ -4,3 +4,4 @@
 
 export { BannerPageSetup } from './banner-page-setup.helper';
 export { BannerReadyWaiter } from './banner-ready-waiter.helper';
+export { sanitizeQueryParam } from './sanitize-query-param.helper';

--- a/src/bounded-contexts/export/infrastructure/helpers/sanitize-query-param.helper.ts
+++ b/src/bounded-contexts/export/infrastructure/helpers/sanitize-query-param.helper.ts
@@ -1,0 +1,24 @@
+/**
+ * Sanitizes query parameters to prevent path traversal and shell injection.
+ * Only allows alphanumeric characters, hyphens, underscores, and spaces.
+ * Returns undefined if input is empty or contains dangerous characters.
+ */
+export function sanitizeQueryParam(input: string | undefined): string | undefined {
+  if (!input) return undefined;
+
+  if (input.includes('..') || input.includes('/') || input.includes('\\')) {
+    return undefined;
+  }
+
+  if (/[;|`$(){}]/.test(input)) {
+    return undefined;
+  }
+
+  const sanitized = input.replace(/[^a-zA-Z0-9\-_ ]/g, '');
+
+  if (sanitized.length < input.length * 0.8) {
+    return undefined;
+  }
+
+  return sanitized || undefined;
+}

--- a/src/bounded-contexts/identity/users/shadow-profile/build-shadow-payload.ts
+++ b/src/bounded-contexts/identity/users/shadow-profile/build-shadow-payload.ts
@@ -1,15 +1,26 @@
+import { z } from 'zod';
 import type { ShadowGithubRepo, ShadowGithubUser } from './ports/github-api.port';
 
-export interface ShadowPayload {
-  headline: string | null;
-  primaryStack: string[];
-  projects: Array<{ name: string; url: string; summary: string }>;
-  stats: {
-    totalRepos: number;
-    nonForkRepos: number;
-    totalStars: number;
-  };
-}
+export const ShadowPayloadSchema = z.object({
+  headline: z.string().max(120).nullable(),
+  primaryStack: z.array(z.string().min(1).max(80)).max(20),
+  projects: z
+    .array(
+      z.object({
+        name: z.string().min(1).max(120),
+        url: z.string().url().max(500),
+        summary: z.string().max(500),
+      }),
+    )
+    .max(10),
+  stats: z.object({
+    totalRepos: z.number().int().min(0),
+    nonForkRepos: z.number().int().min(0),
+    totalStars: z.number().int().min(0),
+  }),
+});
+
+export type ShadowPayload = z.infer<typeof ShadowPayloadSchema>;
 
 const MIN_LANGUAGE_BYTES = 1000;
 

--- a/src/bounded-contexts/identity/users/shadow-profile/shadow-profile.service.ts
+++ b/src/bounded-contexts/identity/users/shadow-profile/shadow-profile.service.ts
@@ -11,9 +11,10 @@
  */
 
 import { Inject, Injectable } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
 import { PrismaService } from '@/bounded-contexts/platform/prisma/prisma.service';
 import { ConflictException } from '@/shared-kernel/exceptions/domain.exceptions';
-import { buildShadowPayload } from './build-shadow-payload';
+import { buildShadowPayload, ShadowPayloadSchema } from './build-shadow-payload';
 import { SHADOW_GITHUB_API, type ShadowGithubApi } from './ports/github-api.port';
 
 export interface ShadowProfileSnapshot {
@@ -35,7 +36,8 @@ export class ShadowProfileService {
   async upsertGithub(input: { token: string; username: string }): Promise<ShadowProfileSnapshot> {
     const user = await this.github.getUser(input.token, input.username);
     const repos = await this.github.listRepositories(input.token, user.login, { limit: 50 });
-    const parsed = buildShadowPayload(user, repos);
+    const parsed = ShadowPayloadSchema.parse(buildShadowPayload(user, repos));
+    const payload = parsed as unknown as Prisma.InputJsonValue;
 
     const row = await this.prisma.shadowProfile.upsert({
       where: { source_externalHandle: { source: 'github', externalHandle: user.login } },
@@ -43,9 +45,9 @@ export class ShadowProfileService {
         source: 'github',
         externalHandle: user.login,
         contactEmail: null,
-        payload: parsed as unknown as object,
+        payload,
       },
-      update: { payload: parsed as unknown as object },
+      update: { payload },
     });
 
     return {

--- a/src/bounded-contexts/integration/testing/index.ts
+++ b/src/bounded-contexts/integration/testing/index.ts
@@ -218,8 +218,8 @@ export class InMemorySectionItemRepository {
  * In-Memory Transaction Handler
  */
 export class InMemoryTransactionHandler {
-  async execute(operations: Array<() => Promise<unknown>>): Promise<unknown[]> {
-    const results: unknown[] = [];
+  async execute<T>(operations: Array<() => Promise<T>>): Promise<T[]> {
+    const results: T[] = [];
     for (const operation of operations) {
       results.push(await operation());
     }

--- a/src/bounded-contexts/jobs/controllers/job.controller.ts
+++ b/src/bounded-contexts/jobs/controllers/job.controller.ts
@@ -13,7 +13,9 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import type { EnglishLevel, JobType, PaymentCurrency, RemotePolicy } from '@prisma/client';
+import { z } from 'zod';
 import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
+import { createZodPipe } from '@/bounded-contexts/platform/common/validation/zod-validation.pipe';
 import { Permission, RequirePermission } from '@/shared-kernel/authorization';
 import {
   parsePaymentCurrencies,
@@ -21,6 +23,22 @@ import {
   parseSkillsCsv,
 } from '../presenters/job.presenter';
 import { JobService } from '../services/job.service';
+
+const JobListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).max(1000).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  search: z.string().max(500).optional(),
+  jobType: z.string().optional(),
+  skills: z.string().max(500).optional(),
+  paymentCurrency: z.string().max(100).optional(),
+  remotePolicy: z.string().max(100).optional(),
+  minEnglishLevel: z.string().optional(),
+});
+
+const PageOnlyQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).max(1000).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
 
 @SdkExport({ tag: 'jobs', description: 'Jobs API' })
 @ApiTags('jobs')
@@ -42,28 +60,18 @@ export class JobController {
   })
   async findAll(
     @Req() req: { user: { userId: string } },
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
-    @Query('search') search?: string,
-    @Query('jobType') jobType?: JobType,
-    @Query('skills') skills?: string,
-    @Query('paymentCurrency') paymentCurrency?: string,
-    @Query('remotePolicy') remotePolicy?: string,
-    @Query('minEnglishLevel') minEnglishLevel?: EnglishLevel,
+    @Query(createZodPipe(JobListQuerySchema)) q: z.infer<typeof JobListQuerySchema>,
   ) {
-    const skillsArray = parseSkillsCsv(skills);
-    const currencyArray = parsePaymentCurrencies(paymentCurrency);
-    const remoteArray = parseRemotePolicies(remotePolicy);
     return this.jobService.findAll(
       {
-        page: page ? Number(page) : undefined,
-        limit: limit ? Number(limit) : undefined,
-        search,
-        jobType,
-        skills: skillsArray,
-        paymentCurrency: currencyArray,
-        remotePolicy: remoteArray,
-        minEnglishLevel,
+        page: q.page,
+        limit: q.limit,
+        search: q.search,
+        jobType: q.jobType as JobType | undefined,
+        skills: parseSkillsCsv(q.skills),
+        paymentCurrency: parsePaymentCurrencies(q.paymentCurrency),
+        remotePolicy: parseRemotePolicies(q.remotePolicy),
+        minEnglishLevel: q.minEnglishLevel as EnglishLevel | undefined,
       },
       req.user.userId,
     );
@@ -78,28 +86,18 @@ export class JobController {
   })
   async findAllWithFitScore(
     @Req() req: { user: { userId: string } },
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
-    @Query('search') search?: string,
-    @Query('jobType') jobType?: JobType,
-    @Query('skills') skills?: string,
-    @Query('paymentCurrency') paymentCurrency?: string,
-    @Query('remotePolicy') remotePolicy?: string,
-    @Query('minEnglishLevel') minEnglishLevel?: EnglishLevel,
+    @Query(createZodPipe(JobListQuerySchema)) q: z.infer<typeof JobListQuerySchema>,
   ) {
-    const skillsArray = parseSkillsCsv(skills);
-    const currencyArray = parsePaymentCurrencies(paymentCurrency);
-    const remoteArray = parseRemotePolicies(remotePolicy);
     return this.jobService.findAllWithFitScore(
       {
-        page: page ? Number(page) : undefined,
-        limit: limit ? Number(limit) : undefined,
-        search,
-        jobType,
-        skills: skillsArray,
-        paymentCurrency: currencyArray,
-        remotePolicy: remoteArray,
-        minEnglishLevel,
+        page: q.page,
+        limit: q.limit,
+        search: q.search,
+        jobType: q.jobType as JobType | undefined,
+        skills: parseSkillsCsv(q.skills),
+        paymentCurrency: parsePaymentCurrencies(q.paymentCurrency),
+        remotePolicy: parseRemotePolicies(q.remotePolicy),
+        minEnglishLevel: q.minEnglishLevel as EnglishLevel | undefined,
       },
       req.user.userId,
     );
@@ -110,14 +108,9 @@ export class JobController {
   @HttpCode(HttpStatus.OK)
   async getMyJobs(
     @Req() req: { user: { userId: string } },
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
+    @Query(createZodPipe(PageOnlyQuerySchema)) q: z.infer<typeof PageOnlyQuerySchema>,
   ) {
-    return this.jobService.getMyJobs(
-      req.user.userId,
-      page ? Number(page) : undefined,
-      limit ? Number(limit) : undefined,
-    );
+    return this.jobService.getMyJobs(req.user.userId, q.page, q.limit);
   }
 
   @Get('bookmarks')
@@ -128,14 +121,9 @@ export class JobController {
   @ApiQuery({ name: 'limit', required: false, type: Number })
   async getBookmarkedJobs(
     @Req() req: { user: { userId: string } },
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
+    @Query(createZodPipe(PageOnlyQuerySchema)) q: z.infer<typeof PageOnlyQuerySchema>,
   ) {
-    return this.jobService.getBookmarkedJobs(
-      req.user.userId,
-      page ? Number(page) : undefined,
-      limit ? Number(limit) : undefined,
-    );
+    return this.jobService.getBookmarkedJobs(req.user.userId, q.page, q.limit);
   }
 
   @Get('recommended')
@@ -146,14 +134,9 @@ export class JobController {
   @ApiQuery({ name: 'limit', required: false, type: Number })
   async getRecommendedJobs(
     @Req() req: { user: { userId: string } },
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
+    @Query(createZodPipe(PageOnlyQuerySchema)) q: z.infer<typeof PageOnlyQuerySchema>,
   ) {
-    return this.jobService.getRecommendedJobs(
-      req.user.userId,
-      page ? Number(page) : undefined,
-      limit ? Number(limit) : undefined,
-    );
+    return this.jobService.getRecommendedJobs(req.user.userId, q.page, q.limit);
   }
 
   @Get('applications')
@@ -164,14 +147,9 @@ export class JobController {
   @ApiQuery({ name: 'limit', required: false, type: Number })
   async getMyApplications(
     @Req() req: { user: { userId: string } },
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
+    @Query(createZodPipe(PageOnlyQuerySchema)) q: z.infer<typeof PageOnlyQuerySchema>,
   ) {
-    return this.jobService.getMyApplications(
-      req.user.userId,
-      page ? Number(page) : undefined,
-      limit ? Number(limit) : undefined,
-    );
+    return this.jobService.getMyApplications(req.user.userId, q.page, q.limit);
   }
 
   @Get(':id')

--- a/src/bounded-contexts/jobs/services/fit-signals.ts
+++ b/src/bounded-contexts/jobs/services/fit-signals.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure scoring helpers for fit calculation. Live in services/ but contain
+ * no I/O — keep them framework-free so they're trivially testable.
+ */
+
+/** 0–100 coverage of `needles` that appear (case-insensitively) in `haystack`. */
+export function percentOverlap(needles: string[], haystack: string[]): number {
+  if (needles.length === 0) return 0;
+  const hs = new Set(haystack.map((h) => h.toLowerCase()));
+  const hit = needles.filter((n) => hs.has(n.toLowerCase())).length;
+  return Math.round((hit / needles.length) * 100);
+}
+
+/**
+ * Coarse soft-skill signal extractor. Scans free-form text for the usual
+ * suspects so we have *something* to feed into the soft-skills dimension
+ * until the skills catalog exposes a canonical list.
+ */
+export function extractSoftSignals(text: string | null | undefined): string[] {
+  if (!text) return [];
+  const vocab = [
+    'communication',
+    'collaboration',
+    'leadership',
+    'ownership',
+    'mentorship',
+    'problem-solving',
+    'autonomy',
+    'teamwork',
+    'english',
+    'portuguese',
+    'stakeholder',
+    'presentation',
+  ];
+  const lower = text.toLowerCase();
+  return vocab.filter((v) => lower.includes(v));
+}

--- a/src/bounded-contexts/jobs/services/job.service.ts
+++ b/src/bounded-contexts/jobs/services/job.service.ts
@@ -10,39 +10,7 @@ import {
 } from '@/shared-kernel/exceptions/domain.exceptions';
 import { ApplicationTrackerService } from '../tracker/application-tracker.service';
 import { computeFitScore, type FitScore } from './compute-fit-score';
-
-/** 0–100 coverage of `needles` that appear (case-insensitively) in `haystack`. */
-function percentOverlap(needles: string[], haystack: string[]): number {
-  if (needles.length === 0) return 0;
-  const hs = new Set(haystack.map((h) => h.toLowerCase()));
-  const hit = needles.filter((n) => hs.has(n.toLowerCase())).length;
-  return Math.round((hit / needles.length) * 100);
-}
-
-/**
- * Coarse soft-skill signal extractor. Scans free-form text for the usual
- * suspects so we have *something* to feed into the soft-skills dimension
- * until the skills catalog exposes a canonical list.
- */
-function extractSoftSignals(text: string | null | undefined): string[] {
-  if (!text) return [];
-  const vocab = [
-    'communication',
-    'collaboration',
-    'leadership',
-    'ownership',
-    'mentorship',
-    'problem-solving',
-    'autonomy',
-    'teamwork',
-    'english',
-    'portuguese',
-    'stakeholder',
-    'presentation',
-  ];
-  const lower = text.toLowerCase();
-  return vocab.filter((v) => lower.includes(v));
-}
+import { extractSoftSignals, percentOverlap } from './fit-signals';
 
 @Injectable()
 export class JobService {

--- a/src/bounded-contexts/notifications/services/weekly-digest.service.ts
+++ b/src/bounded-contexts/notifications/services/weekly-digest.service.ts
@@ -112,7 +112,7 @@ export class WeeklyDigestService {
           createdAt: { gte: cutoff },
         },
       }),
-      this.prisma['skillEndorsement'].count({
+      this.prisma.skillEndorsement.count({
         where: {
           endorsedUserId: userId,
           createdAt: { gte: cutoff },

--- a/src/bounded-contexts/notifications/services/weekly-digest.worker.ts
+++ b/src/bounded-contexts/notifications/services/weekly-digest.worker.ts
@@ -25,9 +25,10 @@ export class WeeklyDigestWorker {
         `Weekly digest sent to ${result.usersEmailed} users (${result.usersSkipped} skipped)`,
       );
     } catch (error) {
-      this.logger.error(
-        `Weekly digest failed: ${error instanceof Error ? error.message : 'unknown'}`,
-      );
+      const message = error instanceof Error ? error.message : 'unknown';
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(`Weekly digest failed: ${message}`, stack);
+      throw error;
     }
   }
 }

--- a/src/bounded-contexts/platform/common/logger/logger.service.ts
+++ b/src/bounded-contexts/platform/common/logger/logger.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, LoggerService } from '@nestjs/common';
 import * as winston from 'winston';
+import { z } from 'zod';
+
+const LogLevelSchema = z.enum(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly']);
 
 @Injectable()
 export class AppLoggerService implements LoggerService {
@@ -8,9 +11,18 @@ export class AppLoggerService implements LoggerService {
 
   constructor() {
     const isProduction = process.env.NODE_ENV === 'production';
+    const defaultLevel = isProduction ? 'info' : 'debug';
+    const parsedLevel = LogLevelSchema.safeParse(process.env.LOG_LEVEL);
+    const level = parsedLevel.success ? parsedLevel.data : defaultLevel;
+    if (process.env.LOG_LEVEL && !parsedLevel.success) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[AppLoggerService] LOG_LEVEL="${process.env.LOG_LEVEL}" invalid, falling back to "${defaultLevel}"`,
+      );
+    }
 
     this.logger = winston.createLogger({
-      level: process.env.LOG_LEVEL ?? (isProduction ? 'info' : 'debug'),
+      level,
       format: winston.format.combine(
         winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
         winston.format.errors({ stack: true }),

--- a/src/bounded-contexts/platform/common/services/s3-upload.service.ts
+++ b/src/bounded-contexts/platform/common/services/s3-upload.service.ts
@@ -5,7 +5,20 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { Injectable } from '@nestjs/common';
+import { z } from 'zod';
 import { AppLoggerService } from '../logger/logger.service';
+
+const MinioConfigSchema = z.object({
+  MINIO_ENDPOINT: z.string().url().optional(),
+  MINIO_ACCESS_KEY: z.string().min(3).optional(),
+  MINIO_SECRET_KEY: z.string().min(3).optional(),
+  MINIO_BUCKET: z
+    .string()
+    .min(3)
+    .max(63)
+    .regex(/^[a-z0-9.-]+$/, 'Bucket must be lowercase alphanumeric with dots/hyphens')
+    .optional(),
+});
 
 @Injectable()
 export class S3UploadService {
@@ -14,11 +27,29 @@ export class S3UploadService {
   private _isEnabled: boolean;
 
   constructor(private readonly logger: AppLoggerService) {
-    const endpoint = process.env.MINIO_ENDPOINT;
-    const accessKeyId = process.env.MINIO_ACCESS_KEY;
-    const secretAccessKey = process.env.MINIO_SECRET_KEY;
-    const bucket = process.env.MINIO_BUCKET;
+    const parsed = MinioConfigSchema.safeParse({
+      MINIO_ENDPOINT: process.env.MINIO_ENDPOINT,
+      MINIO_ACCESS_KEY: process.env.MINIO_ACCESS_KEY,
+      MINIO_SECRET_KEY: process.env.MINIO_SECRET_KEY,
+      MINIO_BUCKET: process.env.MINIO_BUCKET,
+    });
 
+    if (!parsed.success) {
+      this.logger.error(
+        'MinIO config invalid — service disabled',
+        JSON.stringify(parsed.error.flatten()),
+        'S3UploadService',
+      );
+      this._isEnabled = false;
+      return;
+    }
+
+    const {
+      MINIO_ENDPOINT: endpoint,
+      MINIO_ACCESS_KEY: accessKeyId,
+      MINIO_SECRET_KEY: secretAccessKey,
+      MINIO_BUCKET: bucket,
+    } = parsed.data;
     this._isEnabled = !!(endpoint && accessKeyId && secretAccessKey && bucket);
 
     if (this._isEnabled && endpoint && accessKeyId && secretAccessKey) {

--- a/src/bounded-contexts/platform/webhooks/webhook-config.service.ts
+++ b/src/bounded-contexts/platform/webhooks/webhook-config.service.ts
@@ -15,12 +15,31 @@ export interface UpdateWebhookInput {
   enabled?: boolean;
 }
 
+export interface WebhookView {
+  id: string;
+  url: string;
+  events: WebhookEvent[];
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt?: Date;
+}
+
+export interface WebhookDeliveryView {
+  id: string;
+  eventType: string;
+  attempt: number;
+  success: boolean;
+  statusCode: number | null;
+  errorMessage: string | null;
+  createdAt: Date;
+}
+
 @Injectable()
 export class WebhookConfigService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async listForUser(userId: string): Promise<unknown[]> {
-    return this.prisma.webhookConfig.findMany({
+  async listForUser(userId: string): Promise<WebhookView[]> {
+    const rows = await this.prisma.webhookConfig.findMany({
       where: { userId },
       orderBy: { createdAt: 'desc' },
       select: {
@@ -32,12 +51,13 @@ export class WebhookConfigService {
         updatedAt: true,
       },
     });
+    return rows as WebhookView[];
   }
 
   async createForUser(
     userId: string,
     input: CreateWebhookInput,
-  ): Promise<{ webhook: unknown; secret: string }> {
+  ): Promise<{ webhook: WebhookView; secret: string }> {
     const secret = crypto.randomBytes(32).toString('hex');
     const webhook = await this.prisma.webhookConfig.create({
       data: {
@@ -48,16 +68,24 @@ export class WebhookConfigService {
       },
       select: { id: true, url: true, events: true, enabled: true, createdAt: true },
     });
-    return { webhook, secret };
+    return { webhook: webhook as WebhookView, secret };
   }
 
-  async updateForUser(userId: string, id: string, input: UpdateWebhookInput): Promise<unknown> {
+  async updateForUser(userId: string, id: string, input: UpdateWebhookInput): Promise<WebhookView> {
     await this.assertOwnership(userId, id);
-    return this.prisma.webhookConfig.update({
+    const updated = await this.prisma.webhookConfig.update({
       where: { id },
       data: input,
-      select: { id: true, url: true, events: true, enabled: true, updatedAt: true },
+      select: {
+        id: true,
+        url: true,
+        events: true,
+        enabled: true,
+        createdAt: true,
+        updatedAt: true,
+      },
     });
+    return updated as WebhookView;
   }
 
   async deleteForUser(userId: string, id: string): Promise<void> {
@@ -69,9 +97,9 @@ export class WebhookConfigService {
     }
   }
 
-  async listDeliveries(userId: string, webhookId: string): Promise<unknown[]> {
+  async listDeliveries(userId: string, webhookId: string): Promise<WebhookDeliveryView[]> {
     await this.assertOwnership(userId, webhookId);
-    return this.prisma.webhookDelivery.findMany({
+    const rows = await this.prisma.webhookDelivery.findMany({
       where: { webhookId },
       orderBy: { createdAt: 'desc' },
       take: 50,
@@ -85,6 +113,7 @@ export class WebhookConfigService {
         createdAt: true,
       },
     });
+    return rows as WebhookDeliveryView[];
   }
 
   private async assertOwnership(userId: string, id: string): Promise<void> {

--- a/src/bounded-contexts/presentation/public-resumes/controllers/share-management.controller.ts
+++ b/src/bounded-contexts/presentation/public-resumes/controllers/share-management.controller.ts
@@ -15,11 +15,13 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiBearerAuth, ApiOperation, ApiProduces, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
 import type { UserPayload } from '@/bounded-contexts/identity/shared-kernel/infrastructure';
 import { ApiDataResponse } from '@/bounded-contexts/platform/common/decorators/api-data-response.decorator';
 import { CurrentUser } from '@/bounded-contexts/platform/common/decorators/current-user.decorator';
 import { SdkExport } from '@/bounded-contexts/platform/common/decorators/sdk-export.decorator';
 import type { DataResponse } from '@/bounded-contexts/platform/common/dto/api-response.dto';
+import { createZodPipe } from '@/bounded-contexts/platform/common/validation/zod-validation.pipe';
 import { Permission, RequirePermission } from '@/shared-kernel/authorization';
 import {
   ShareCreateDataDto,
@@ -28,7 +30,6 @@ import {
 } from '../dto/share-management-response.dto';
 import {
   type AliasPayload,
-  type SharePayload,
   toAliasPayload,
   toAliasPayloadList,
   toSharePayload,
@@ -37,12 +38,29 @@ import {
 import { QrCodeService } from '../services/qr-code.service';
 import { ResumeShareService } from '../services/resume-share.service';
 
-interface CreateShare {
-  resumeId: string;
-  slug?: string;
-  password?: string;
-  expiresAt?: string;
-}
+const CreateShareSchema = z.object({
+  resumeId: z.string().min(1),
+  slug: z
+    .string()
+    .min(3)
+    .max(80)
+    .regex(/^[a-zA-Z0-9-]+$/, 'Slug must be alphanumeric with hyphens')
+    .optional(),
+  password: z.string().min(4).max(200).optional(),
+  expiresAt: z.coerce.date().optional(),
+});
+
+const AddAliasSchema = z.object({
+  slug: z
+    .string()
+    .min(3)
+    .max(80)
+    .regex(/^[a-zA-Z0-9-]+$/, 'Slug must be alphanumeric with hyphens'),
+});
+
+const QrSizeSchema = z.object({
+  size: z.coerce.number().int().min(64).max(1024).default(256),
+});
 
 @SdkExport({ tag: 'resumes', description: 'Share Management API' })
 @ApiTags('shares')
@@ -65,19 +83,13 @@ export class ShareManagementController {
   })
   async createShare(
     @CurrentUser() user: UserPayload,
-    @Body() dto: CreateShare,
+    @Body(createZodPipe(CreateShareSchema)) dto: z.infer<typeof CreateShareSchema>,
   ): Promise<DataResponse<ShareCreateDataDto>> {
-    const share = await this.shareService.createShare(user.userId, {
-      ...dto,
-      expiresAt: dto.expiresAt ? new Date(dto.expiresAt) : undefined,
-    });
-    const sharePayload = toSharePayload(share);
-
+    const share = await this.shareService.createShare(user.userId, dto);
     return {
       success: true,
-      data: { share: sharePayload },
-      ...sharePayload,
-    } as DataResponse<ShareCreateDataDto> & SharePayload;
+      data: { share: toSharePayload(share) },
+    };
   }
 
   @Get('resume/:resumeId')
@@ -89,13 +101,10 @@ export class ShareManagementController {
     @CurrentUser() user: UserPayload,
   ): Promise<DataResponse<ShareListDataDto>> {
     const shares = await this.shareService.listUserShares(user.userId, resumeId);
-    const sharePayloads = toSharePayloadList(shares);
-
     return {
       success: true,
-      data: { shares: sharePayloads },
-      shares: sharePayloads,
-    } as DataResponse<ShareListDataDto> & { shares: SharePayload[] };
+      data: { shares: toSharePayloadList(shares) },
+    };
   }
 
   @Delete(':shareId')
@@ -125,7 +134,7 @@ export class ShareManagementController {
   async addAlias(
     @CurrentUser() user: UserPayload,
     @Param('shareId') shareId: string,
-    @Body() dto: { slug: string },
+    @Body(createZodPipe(AddAliasSchema)) dto: z.infer<typeof AddAliasSchema>,
   ): Promise<DataResponse<{ alias: AliasPayload }>> {
     const alias = await this.shareService.addAlias(user.userId, shareId, dto.slug);
     return {
@@ -163,20 +172,17 @@ export class ShareManagementController {
   async getQrCodePng(
     @CurrentUser() user: UserPayload,
     @Param('shareId') shareId: string,
-    @Query('size') sizeParam?: string,
+    @Query(createZodPipe(QrSizeSchema)) q: z.infer<typeof QrSizeSchema>,
   ): Promise<StreamableFile> {
     const share = await this.shareService.getShareWithOwner(shareId);
     if (!share) throw new NotFoundException('Share not found');
     if (share.resume.userId !== user.userId)
       throw new ForbiddenException('You do not have access to this share');
 
-    const size = sizeParam
-      ? Math.min(1024, Math.max(64, Number.parseInt(sizeParam, 10) || 256))
-      : 256;
     const baseUrl = this.configService.get<string>('PUBLIC_APP_URL') ?? 'https://patchcareers.com';
     const targetUrl = `${baseUrl.replace(/\/$/, '')}/u/${share.slug}`;
 
-    const buffer = await this.qrCodeService.generatePng(targetUrl, { size });
+    const buffer = await this.qrCodeService.generatePng(targetUrl, { size: q.size });
     return new StreamableFile(buffer);
   }
 

--- a/src/bounded-contexts/presentation/public-resumes/services/resume-share.service.spec.ts
+++ b/src/bounded-contexts/presentation/public-resumes/services/resume-share.service.spec.ts
@@ -48,57 +48,81 @@ describe('ResumeShareService', () => {
   };
 
   // Build Prisma-compatible interface from in-memory repositories
-  const buildPrismaService = () => ({
+  type Mocked = ReturnType<typeof mock>;
+  type PrismaStub = {
+    $transaction: Mocked;
     resumeShare: {
-      create: mock(
-        async (args: {
-          data: {
-            slug: string;
-            password?: string | null;
-            expiresAt?: Date | null;
-            resumeId: string;
-          };
-        }) => {
-          return shareRepo.create({
-            resumeId: args.data.resumeId,
-            slug: args.data.slug,
-            password: args.data.password ?? null,
-            expiresAt: args.data.expiresAt ?? null,
-          });
-        },
-      ),
-      findUnique: mock(
-        async (args: { where: { id?: string; slug?: string }; include?: unknown }) => {
-          const share = await shareRepo.findUnique(args.where);
-          if (!share) return null;
-          if (args.include) {
-            const resume = await resumeRepo.findUnique({ id: share.resumeId });
-            return { ...share, resume };
-          }
-          return share;
-        },
-      ),
-      findMany: mock(async (args: { where: { resumeId: string }; orderBy?: unknown }) => {
-        return shareRepo.findMany({ resumeId: args.where.resumeId });
-      }),
-      delete: mock(async (args: { where: { id: string } }) => {
-        return shareRepo.delete({ id: args.where.id });
-      }),
-    },
-    resume: {
-      findUnique: mock(
-        async (args: { where: { id: string }; select?: unknown; include?: unknown }) => {
-          const resume = await resumeRepo.findUnique({ id: args.where.id });
-          if (!resume) return null;
-          // If select only includes userId, return just that
-          if (args.select && 'userId' in (args.select as object)) {
-            return { userId: resume.userId };
-          }
-          return resume;
-        },
-      ),
-    },
-  });
+      create: Mocked;
+      findUnique: Mocked;
+      findMany: Mocked;
+      delete: Mocked;
+    };
+    resume: { findUnique: Mocked };
+    resumeShareAlias?: {
+      create: Mocked;
+      findUnique: Mocked;
+      findMany: Mocked;
+      delete: Mocked;
+    };
+  };
+  const buildPrismaService = (): PrismaStub => {
+    const service = {} as PrismaStub;
+    service.$transaction = mock(
+      async <T>(cb: (tx: PrismaStub) => Promise<T>): Promise<T> => cb(service),
+    );
+    Object.assign(service, {
+      resumeShare: {
+        create: mock(
+          async (args: {
+            data: {
+              slug: string;
+              password?: string | null;
+              expiresAt?: Date | null;
+              resumeId: string;
+            };
+          }) => {
+            return shareRepo.create({
+              resumeId: args.data.resumeId,
+              slug: args.data.slug,
+              password: args.data.password ?? null,
+              expiresAt: args.data.expiresAt ?? null,
+            });
+          },
+        ),
+        findUnique: mock(
+          async (args: { where: { id?: string; slug?: string }; include?: unknown }) => {
+            const share = await shareRepo.findUnique(args.where);
+            if (!share) return null;
+            if (args.include) {
+              const resume = await resumeRepo.findUnique({ id: share.resumeId });
+              return { ...share, resume };
+            }
+            return share;
+          },
+        ),
+        findMany: mock(async (args: { where: { resumeId: string }; orderBy?: unknown }) => {
+          return shareRepo.findMany({ resumeId: args.where.resumeId });
+        }),
+        delete: mock(async (args: { where: { id: string } }) => {
+          return shareRepo.delete({ id: args.where.id });
+        }),
+      },
+      resume: {
+        findUnique: mock(
+          async (args: { where: { id: string }; select?: unknown; include?: unknown }) => {
+            const resume = await resumeRepo.findUnique({ id: args.where.id });
+            if (!resume) return null;
+            // If select only includes userId, return just that
+            if (args.select && 'userId' in (args.select as object)) {
+              return { userId: resume.userId };
+            }
+            return resume;
+          },
+        ),
+      },
+    });
+    return service;
+  };
 
   const buildCacheService = () => ({
     get: mock(async <T>(key: string): Promise<T | null> => {
@@ -394,8 +418,7 @@ describe('ResumeShareService', () => {
       createdShareId = created.id;
 
       // Wire alias prisma surface used by service
-      // biome-ignore lint/suspicious/noExplicitAny: test stub typed loosely
-      (prismaService as any).resumeShareAlias = {
+      prismaService.resumeShareAlias = {
         create: mock(async (args: { data: { shareId: string; slug: string } }) => {
           const id = `alias-${aliases.size + 1}`;
           const record = { id, shareId: args.data.shareId, slug: args.data.slug };

--- a/src/bounded-contexts/presentation/public-resumes/services/resume-share.service.ts
+++ b/src/bounded-contexts/presentation/public-resumes/services/resume-share.service.ts
@@ -32,58 +32,48 @@ export class ResumeShareService {
   async createShare(userId: string, dto: CreateShare) {
     const slug = dto.slug ?? this.generateSlug();
 
-    // Validate custom slug
     if (dto.slug && !this.isValidSlug(dto.slug)) {
       throw new BadRequestException(
         'Invalid slug format. Use alphanumeric characters and hyphens only.',
       );
     }
 
-    // Check slug uniqueness
-    const existing = await this.prisma.resumeShare.findUnique({
-      where: { slug },
-    });
-
-    if (existing) {
-      throw new ConflictException('Slug already in use');
-    }
-
-    // Hash password if provided
     const hashedPassword = dto.password
       ? await Bun.password.hash(dto.password, { algorithm: 'bcrypt', cost: 10 })
       : null;
 
-    // Verify resume ownership
-    const resume = await this.prisma.resume.findUnique({
-      where: { id: dto.resumeId },
-      select: { userId: true },
-    });
+    const { share, ownerId } = await this.prisma.$transaction(async (tx) => {
+      const existing = await tx.resumeShare.findUnique({ where: { slug } });
+      if (existing) {
+        throw new ConflictException('Slug already in use');
+      }
 
-    if (!resume) {
-      throw new NotFoundException('Resume not found');
-    }
+      const resume = await tx.resume.findUnique({
+        where: { id: dto.resumeId },
+        select: { userId: true },
+      });
 
-    if (resume.userId !== userId) {
-      throw new ForbiddenException('You do not have access to this resume');
-    }
+      if (!resume) {
+        throw new NotFoundException('Resume not found');
+      }
 
-    const share = await this.prisma.resumeShare.create({
-      data: {
-        resumeId: dto.resumeId,
-        slug,
-        password: hashedPassword,
-        expiresAt: dto.expiresAt,
-      },
-    });
+      if (resume.userId !== userId) {
+        throw new ForbiddenException('You do not have access to this resume');
+      }
 
-    if (resume) {
-      this.eventPublisher.publish(
-        new ResumePublishedEvent(dto.resumeId, {
-          userId: resume.userId,
+      const created = await tx.resumeShare.create({
+        data: {
+          resumeId: dto.resumeId,
           slug,
-        }),
-      );
-    }
+          password: hashedPassword,
+          expiresAt: dto.expiresAt,
+        },
+      });
+
+      return { share: created, ownerId: resume.userId };
+    });
+
+    this.eventPublisher.publish(new ResumePublishedEvent(dto.resumeId, { userId: ownerId, slug }));
 
     return share;
   }

--- a/src/bounded-contexts/presentation/themes/services/theme-crud.service.ts
+++ b/src/bounded-contexts/presentation/themes/services/theme-crud.service.ts
@@ -55,13 +55,22 @@ export class ThemeCrudService {
       },
     });
 
-    this.previewService.generateAndUploadPreview(theme.id).catch((err) => {
-      this.logger.warn(
-        `Preview generation failed for theme ${theme.id}: ${(err as Error).message}`,
-      );
-    });
+    void this.runPreviewGeneration(theme.id);
 
     return theme;
+  }
+
+  private async runPreviewGeneration(themeId: string): Promise<void> {
+    try {
+      await this.previewService.generateAndUploadPreview(themeId);
+    } catch (err) {
+      const error = err as Error;
+      this.logger.error(
+        `Preview generation failed for theme ${themeId}: ${error.message}`,
+        error.stack,
+        { themeId },
+      );
+    }
   }
 
   async updateThemeForUser(adminId: string, themeId: string, updateThemeData: UpdateTheme) {

--- a/src/bounded-contexts/resumes/core/controllers/generic-resume-sections.controller.ts
+++ b/src/bounded-contexts/resumes/core/controllers/generic-resume-sections.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -98,6 +109,7 @@ export class GenericResumeSectionsController {
   }
 
   @Post(':sectionTypeKey/items')
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Create section item in a dynamic section type' })
   @ApiParam({ name: 'resumeId', description: 'Resume ID' })
   @ApiParam({

--- a/src/bounded-contexts/social/services/skill-decay.service.ts
+++ b/src/bounded-contexts/social/services/skill-decay.service.ts
@@ -38,7 +38,7 @@ export class SkillDecayService {
     let flagged = 0;
     for (const row of stale) {
       try {
-        const already = await this.prisma['skillDecayLog'].findUnique({
+        const already = await this.prisma.skillDecayLog.findUnique({
           where: {
             userId_skillName_quarterKey: {
               userId: row.userId,
@@ -51,7 +51,7 @@ export class SkillDecayService {
 
         const days = Math.floor((now.getTime() - row.updatedAt.getTime()) / MS_PER_DAY);
         await this.emit({ userId: row.userId, skillName: row.skillName, daysSinceTouched: days });
-        await this.prisma['skillDecayLog'].create({
+        await this.prisma.skillDecayLog.create({
           data: {
             userId: row.userId,
             skillName: row.skillName,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import { z } from 'zod';
 import {
   configureCors,
   configureSecurityHeaders,
@@ -55,7 +56,8 @@ async function bootstrap() {
     configureSwagger(app);
   }
 
-  const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
+  const PortSchema = z.coerce.number().int().min(1).max(65535).default(3001);
+  const port = PortSchema.parse(process.env.PORT);
   await app.listen(port);
 
   logger.log(`Application is running on: ${await app.getUrl()}`);

--- a/src/shared-kernel/schemas/user/user.schema.ts
+++ b/src/shared-kernel/schemas/user/user.schema.ts
@@ -6,7 +6,8 @@ import {
 } from '@/bounded-contexts/identity/users/domain/schemas/professional-profile.schema';
 import { UsernameSchema } from '@/bounded-contexts/identity/users/domain/schemas/username.schema';
 
-// Local schemas (TODO: move to schemas/primitives if needed)
+// Local primitives — kept inline because they're only used by user DTOs.
+// Promote to schemas/primitives if a second consumer appears.
 const FullNameSchema = z.string().trim().min(2, 'Name must be at least 2 characters').max(100);
 const PhoneSchema = z.string().max(20).optional();
 const UserLocationSchema = z.string().max(100).optional();

--- a/swagger-generation-report.json
+++ b/swagger-generation-report.json
@@ -3,7 +3,7 @@
   "generatedBy": "nest-swagger",
   "paths": 323,
   "operations": 387,
-  "schemas": 267,
+  "schemas": 272,
   "tags": [
     "auth",
     "export",

--- a/swagger.json
+++ b/swagger.json
@@ -14505,8 +14505,55 @@
         "operationId": "search_search",
         "parameters": [
           {
-            "name": "q",
-            "required": true,
+            "name": "sortBy",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "enum": [
+                "relevance",
+                "date",
+                "views"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Default 20, max 100",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Default 1, max 1000",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "maxExp",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "minExp",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "location",
+            "required": false,
             "in": "query",
             "schema": {
               "type": "string"
@@ -14514,56 +14561,18 @@
           },
           {
             "name": "skills",
-            "required": true,
+            "required": false,
             "in": "query",
+            "description": "Comma-separated",
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "location",
-            "required": true,
+            "name": "q",
+            "required": false,
             "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "minExp",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "maxExp",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "sortBy",
-            "required": true,
-            "in": "query",
+            "description": "Free-text query (max 500)",
             "schema": {
               "type": "string"
             }
@@ -14607,17 +14616,19 @@
         "operationId": "search_suggestions",
         "parameters": [
           {
-            "name": "prefix",
-            "required": true,
+            "name": "limit",
+            "required": false,
             "in": "query",
+            "description": "Default 10, max 50",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           },
           {
-            "name": "limit",
-            "required": true,
+            "name": "prefix",
+            "required": false,
             "in": "query",
+            "description": "Max 50 chars",
             "schema": {
               "type": "string"
             }
@@ -14670,10 +14681,11 @@
           },
           {
             "name": "limit",
-            "required": true,
+            "required": false,
             "in": "query",
+            "description": "Default 5, max 50",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -19375,60 +19387,24 @@
         "operationId": "jobs_findAll",
         "parameters": [
           {
-            "name": "page",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "search",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "skills",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "paymentCurrency",
+            "name": "minEnglishLevel",
             "required": false,
             "in": "query",
-            "description": "CSV of BRL|USD|EUR|GBP",
-            "schema": {
-              "type": "string"
-            }
+            "description": "Max level the viewer accepts. Returns jobs whose required level is ≤ this (or null).",
+            "schema": {}
           },
           {
             "name": "remotePolicy",
             "required": false,
             "in": "query",
             "description": "CSV of REMOTE|HYBRID|ONSITE",
-            "schema": {
-              "type": "string"
-            }
+            "schema": {}
           },
           {
-            "name": "minEnglishLevel",
+            "name": "paymentCurrency",
             "required": false,
             "in": "query",
-            "description": "Max level the viewer accepts. Returns jobs whose required level is ≤ this (or null).",
+            "description": "CSV of BRL|USD|EUR|GBP",
             "schema": {}
           }
         ],
@@ -19479,56 +19455,7 @@
     "/api/v1/jobs/with-fit-score": {
       "get": {
         "operationId": "jobs_findAllWithFitScore",
-        "parameters": [
-          {
-            "name": "page",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "search",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "skills",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "paymentCurrency",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "remotePolicy",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "401": {
             "description": "Authentication required"
@@ -19554,24 +19481,7 @@
     "/api/v1/jobs/mine": {
       "get": {
         "operationId": "jobs_getMyJobs",
-        "parameters": [
-          {
-            "name": "page",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "401": {
             "description": "Authentication required"
@@ -19598,7 +19508,7 @@
         "operationId": "jobs_getBookmarkedJobs",
         "parameters": [
           {
-            "name": "page",
+            "name": "limit",
             "required": false,
             "in": "query",
             "schema": {
@@ -19606,7 +19516,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "page",
             "required": false,
             "in": "query",
             "schema": {
@@ -19641,7 +19551,7 @@
         "operationId": "jobs_getRecommendedJobs",
         "parameters": [
           {
-            "name": "page",
+            "name": "limit",
             "required": false,
             "in": "query",
             "schema": {
@@ -19649,7 +19559,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "page",
             "required": false,
             "in": "query",
             "schema": {
@@ -19684,7 +19594,7 @@
         "operationId": "jobs_getMyApplications",
         "parameters": [
           {
-            "name": "page",
+            "name": "limit",
             "required": false,
             "in": "query",
             "schema": {
@@ -19692,7 +19602,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "page",
             "required": false,
             "in": "query",
             "schema": {
@@ -20113,7 +20023,29 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "This week's curated batch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiResponseDto"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/CurrentBatchDataDto"
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
           }
         },
         "security": [
@@ -20142,7 +20074,29 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Application created or already existed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiResponseDto"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/ApproveResultDto"
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
           }
         },
         "security": [
@@ -20171,7 +20125,29 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Item marked as rejected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiResponseDto"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/RejectResultDto"
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
           }
         },
         "security": [
@@ -20190,6 +20166,31 @@
         "operationId": "automation_run",
         "parameters": [],
         "responses": {
+          "200": {
+            "description": "Batch apply summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiResponseDto"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/RageApplyResultDto"
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "401": {
             "description": "Authentication required"
           },
@@ -33290,6 +33291,98 @@
         },
         "required": [
           "type"
+        ]
+      },
+      "CurrentBatchDataDto": {
+        "type": "object",
+        "properties": {
+          "batch": {
+            "type": "object",
+            "nullable": true,
+            "description": "This week's batch or null if none active"
+          }
+        },
+        "required": [
+          "batch"
+        ]
+      },
+      "ApproveResultDto": {
+        "type": "object",
+        "properties": {
+          "applicationId": {
+            "type": "string",
+            "example": "app_abc123"
+          },
+          "alreadyApplied": {
+            "type": "boolean",
+            "example": false
+          }
+        },
+        "required": [
+          "applicationId",
+          "alreadyApplied"
+        ]
+      },
+      "RejectResultDto": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "example": "item_abc123"
+          }
+        },
+        "required": [
+          "itemId"
+        ]
+      },
+      "RageApplyFailureDto": {
+        "type": "object",
+        "properties": {
+          "jobId": {
+            "type": "string",
+            "example": "job_abc123"
+          },
+          "reason": {
+            "type": "string",
+            "example": "Tailor service timeout"
+          }
+        },
+        "required": [
+          "jobId",
+          "reason"
+        ]
+      },
+      "RageApplyResultDto": {
+        "type": "object",
+        "properties": {
+          "attempted": {
+            "type": "number",
+            "example": 18,
+            "description": "How many jobs we tried to apply to"
+          },
+          "submitted": {
+            "type": "number",
+            "example": 12,
+            "description": "Successful submissions"
+          },
+          "skippedExisting": {
+            "type": "number",
+            "example": 4,
+            "description": "Skipped because user already applied"
+          },
+          "failed": {
+            "description": "Per-job failures with reason",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RageApplyFailureDto"
+            }
+          }
+        },
+        "required": [
+          "attempted",
+          "submitted",
+          "skippedExisting",
+          "failed"
         ]
       },
       "CreateSuccessStoryDto": {

--- a/test/static-analysis/architecture/generic-sections-guardrail.architecture.spec.ts
+++ b/test/static-analysis/architecture/generic-sections-guardrail.architecture.spec.ts
@@ -187,7 +187,12 @@ describe('Architecture - Generic Sections Guardrail', () => {
         const normalizedLine = line.replace(/\s+/g, '');
 
         for (const delegate of LEGACY_PRISMA_DELEGATES) {
-          if (normalizedLine.includes(delegate)) {
+          // Word-boundary so `prisma.skill` doesn't accidentally match
+          // valid current models like `prisma.skillEndorsement` or
+          // `prisma.skillDecayLog`. Must not be followed by an identifier char.
+          const escaped = delegate.replace(/[.]/g, '\\.');
+          const pattern = new RegExp(`${escaped}(?![A-Za-z0-9_])`);
+          if (pattern.test(normalizedLine)) {
             violations.push(
               `${filePath}:${index + 1} uses removed legacy Prisma delegate ${delegate}`,
             );


### PR DESCRIPTION
## Summary

Resolves **30 of 35 items** from the deep backend audit (5 deferred or N/A documented at the bottom).

Branched from `homolog`. All 5 pre-commit checks green: typecheck ✓, lint ✓, unit (2876 pass / 0 fail) ✓, arch (42 pass) ✓, contract ✓.

## What changed

### 🔴 Critical (data-integrity / perf)
- **B1** `resume-share.service`: wrap slug-uniqueness + ownership + create in `\$transaction`. Two concurrent requests can no longer grab the same slug.
- **B2** `shadow-profile.service`: validate the GitHub-derived payload through a Zod schema before persisting. No more `as unknown as object`.
- **B3** `auto-apply.worker`: wrap unique-constraint check + insert in `\$transaction` so two scheduler runs can't double-apply.
- **B4** `auto-apply.worker`: per-user `queue.add()` loop → `queue.addBulk()`. Was 10k round-trips for 10k users.

### 🟡 Medium
**Validation (B5–B9)** — Zod pipes on `search` and `jobs` controllers + `share-management` body. NaN no longer reaches Prisma; query params bounded against DoS.

**API design (B10–B16)** — `@HttpCode(201)`; typed DTOs replace `Promise<unknown>`; share-management response shape unified (frontend's triple-fallback can die); `@ApiQuery` documented for OpenAPI.

**Performance (B17–B18)** — search-resumes use-case: `findUnique`/`findMany` moved from `include` to `select` so we stop loading full resume rows when we only need skill names.

**Observability (B20–B23)** — workers rethrow on total failure (BullMQ retries / cron flips red); curated-selector tracks failure ratio; theme-crud orphan `.catch()` extracted to a helper with structured logging.

**Auth/security (B24–B25)** — `@Throttle 30/min` on the `@Public()` search endpoint; rage-apply revalidates `user.isActive` so a deactivated account can't fire batch applications with a stale JWT.

**Config (B26–B28)** — Zod validates `PORT`, MinIO env vars, and `LOG_LEVEL` at boot. No more silent fallbacks for typos.

**Architecture (B29–B30)** — `sanitizeQueryParam` extracted from export controller; `percentOverlap`/`extractSoftSignals` extracted from job service. Both pure, framework-free.

**Arch test fix** — the legacy-Prisma-delegate guardrail used a substring `.includes('prisma.skill')` check that flagged valid current models like `prisma.skillEndorsement` / `prisma.skillDecayLog`. Tightened to a word-boundary regex; removed the `prisma['skillFoo']` bracket-syntax callsites that existed only to dodge the broken check.

### 🟢 Polish (B31–B35)
TODO comments rewritten to be intentional; `Promise<unknown>` in test transaction handler tightened to generic `<T>`; inline `RequestWithUser` replaced with shared `AuthenticatedRequest`.

## Deferred

- **B19** `jobs.service.findById` select tightening — would change response shape; revisit when UI tolerance is known.
- **B33** ~60 spec files using `as unknown as` — bulk test refactor not worth the risk in a hardening PR.

## Test plan

- [x] Pre-commit: typecheck, lint, unit (2876/2876), arch (42/42), contract (42/42), swagger snapshot
- [ ] Manual smoke after merge: create share (race protection), rage-apply with deactivated user (now 404), search with `limit=999999` (now 400), boot with `PORT=abc` (now hard-fail)