### PR TITLE
ci(release): allow build-docker on workflow_dispatch when tag exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,14 @@ jobs:
 
   build-docker:
     needs: finalize-release
-    if: needs.finalize-release.outputs.released == 'true'
+    # Two paths in:
+    #  - normal: finalize created a new tag/release (`released == 'true'`)
+    #  - recovery: manual workflow_dispatch — run docker build for whatever
+    #    version is in package.json, even when the tag already exists. Used
+    #    to republish an image after a transient docker build failure
+    #    (the original failure mode that bit v0.2.2: GITHUB_TOKEN wasn't
+    #    being passed to the build secret in the shared workflow).
+    if: needs.finalize-release.outputs.tag != '' && (needs.finalize-release.outputs.released == 'true' || github.event_name == 'workflow_dispatch')
     uses: octopus-synapse/octopus-workflows/.github/workflows/_release-docker.yml@v1
     with:
       tag: ${{ needs.finalize-release.outputs.tag }}


### PR DESCRIPTION
Recovery path for the v0.2.2 docker build failure.

## Problem
\`build-docker\` is gated by \`if: needs.finalize-release.outputs.released == 'true'\`, which is only true when finalize creates a NEW tag. When a build fails (as happened with v0.2.2 — the shared workflow wasn't passing GITHUB_TOKEN to the build secret in the Dockerfile), re-dispatching the workflow leaves build-docker skipped because the tag already exists.

## Fix
Allow build-docker on workflow_dispatch for whatever tag is in package.json. The shared scaffold workflow has been fixed (octopus-workflows v1.5.1) so this re-dispatch will succeed.

## Test plan
- [ ] Merge → manually dispatch \`Release\` workflow on main → confirm build-docker runs and image lands at \`ghcr.io/octopus-synapse/profile-services:v0.2.2\`