### PR TITLE
fix(release): filter patch changelog by baseDate (fixes #218 100-entry bloat)

### DIFF
--- a/.attestation
+++ b/.attestation
@@ -1,38 +1,38 @@
 {
   "version": "3",
-  "tree_hash": "43a3d6360e676043c672850d1455fe17d8e7851f",
+  "tree_hash": "e53b50ed927df8c9d8e961c6190322da37b7be8b",
   "checks": "swagger typecheck lint unit arch contract",
   "metrics": {
     "typecheck": {
       "status": "ok",
-      "time_ms": 5716
+      "time_ms": 4861
     },
     "lint": {
       "status": "ok",
-      "time_ms": 1261
+      "time_ms": 1213
     },
     "unit": {
       "status": "ok",
-      "time_ms": 6587,
+      "time_ms": 6280,
       "passed": 2876,
       "failed": 0,
       "skipped": 0
     },
     "arch": {
       "status": "ok",
-      "time_ms": 1785,
+      "time_ms": 1932,
       "passed": 42,
       "failed": 0,
       "skipped": 1
     },
     "contract": {
       "status": "ok",
-      "time_ms": 836,
+      "time_ms": 910,
       "passed": 42,
       "failed": 0,
       "skipped": 0
     }
   },
-  "timestamp": "2026-04-20T13:25:45Z",
+  "timestamp": "2026-04-20T13:41:26Z",
   "git_user": "enzo.patti@aluno.senai.br"
 }

--- a/.attestation
+++ b/.attestation
@@ -1,38 +1,38 @@
 {
   "version": "3",
-  "tree_hash": "f8b7824ed934e11afd510d6ab34eea9c62f41dbc",
+  "tree_hash": "43a3d6360e676043c672850d1455fe17d8e7851f",
   "checks": "swagger typecheck lint unit arch contract",
   "metrics": {
     "typecheck": {
       "status": "ok",
-      "time_ms": 4547
+      "time_ms": 5716
     },
     "lint": {
       "status": "ok",
-      "time_ms": 1251
+      "time_ms": 1261
     },
     "unit": {
       "status": "ok",
-      "time_ms": 6305,
+      "time_ms": 6587,
       "passed": 2876,
       "failed": 0,
       "skipped": 0
     },
     "arch": {
       "status": "ok",
-      "time_ms": 1776,
+      "time_ms": 1785,
       "passed": 42,
       "failed": 0,
       "skipped": 1
     },
     "contract": {
       "status": "ok",
-      "time_ms": 720,
+      "time_ms": 836,
       "passed": 42,
       "failed": 0,
       "skipped": 0
     }
   },
-  "timestamp": "2026-04-20T03:38:15Z",
+  "timestamp": "2026-04-20T13:25:45Z",
   "git_user": "enzo.patti@aluno.senai.br"
 }

--- a/src/release/cli/gen-changelog.ts
+++ b/src/release/cli/gen-changelog.ts
@@ -70,7 +70,7 @@ async function main(): Promise<void> {
 
     switch (input.releaseType) {
       case 'patch':
-        changelog = formatPatchChangelog(input.prs as PullRequest[]);
+        changelog = formatPatchChangelog(input.prs as PullRequest[], input.baseDate);
         break;
 
       case 'minor':

--- a/src/release/domain/changelog.ts
+++ b/src/release/domain/changelog.ts
@@ -54,12 +54,21 @@ function findPatchesForMinor(patchTags: Tag[], majorNum: number, minorNum: numbe
 
 /**
  * Formats a simple changelog for PATCH releases.
- * Just a flat list of PRs.
+ * Flat list of PRs merged since the last tagged release.
+ *
+ * When `baseDate` is provided, only PRs merged strictly AFTER it are
+ * included — this is the behavior callers want 99% of the time because
+ * `gather-changelog-data` ships every merged PR on main + homolog (no
+ * date filter upstream), so without this guard every patch release
+ * regurgitates the entire history. `baseDate` is optional only so the
+ * older test fixtures that call `formatPatchChangelog(prs)` directly
+ * keep working.
  */
-export function formatPatchChangelog(prs: PullRequest[]): string {
+export function formatPatchChangelog(prs: PullRequest[], baseDate?: string): string {
   const lines: string[] = ['### Changes', ''];
+  const relevantPRs = baseDate ? prs.filter((pr) => pr.mergedAt > baseDate) : prs;
 
-  for (const pr of prs) {
+  for (const pr of relevantPRs) {
     lines.push(`- ${pr.title} #${pr.number}`);
   }
 

--- a/test/infrastructure/integration/anti-ghosting.integration.spec.ts
+++ b/test/infrastructure/integration/anti-ghosting.integration.spec.ts
@@ -52,6 +52,9 @@ describe('Anti-ghosting Integration', () => {
     await prisma.jobApplicationEvent.deleteMany({ where: { applicationId } });
     await prisma.jobApplication.delete({ where: { id: applicationId } });
     await prisma.job.delete({ where: { id: jobId } });
+    // Anti-ghosting service creates Notification rows as part of scanAndNotify;
+    // they FK to User and must be cleared before the user delete.
+    await prisma.notification.deleteMany({ where: { userId } });
     await prisma.user.delete({ where: { id: userId } });
     await closeApp();
   });

--- a/test/infrastructure/integration/public-resumes.integration.spec.ts
+++ b/test/infrastructure/integration/public-resumes.integration.spec.ts
@@ -59,13 +59,16 @@ describe('Public Resumes Integration', () => {
           expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
         });
 
+      // Response shape was unified to the canonical `{ success, data: { share } }`
+      // envelope by the backend-audit hardening PR (#213). The duplicated
+      // top-level fields (slug, resumeId, isActive, publicUrl) are gone.
       expect(response.status).toBe(201);
-      expect(response.body.slug).toBe('my-awesome-resume');
-      expect(response.body.resumeId).toBe(resumeId);
-      expect(response.body.isActive).toBe(true);
-      expect(response.body).toHaveProperty('publicUrl');
+      expect(response.body.data.share.slug).toBe('my-awesome-resume');
+      expect(response.body.data.share.resumeId).toBe(resumeId);
+      expect(response.body.data.share.isActive).toBe(true);
+      expect(response.body.data.share).toHaveProperty('publicUrl');
 
-      shareSlug = response.body.slug;
+      shareSlug = response.body.data.share.slug;
     });
 
     it('should create a password-protected share', async () => {
@@ -75,8 +78,8 @@ describe('Public Resumes Integration', () => {
       });
 
       expect(response.status).toBe(201);
-      expect(response.body).toHaveProperty('slug');
-      expect(response.body.hasPassword).toBe(true);
+      expect(response.body.data.share).toHaveProperty('slug');
+      expect(response.body.data.share.hasPassword).toBe(true);
     });
 
     it('should list user shares for a resume', async () => {
@@ -250,7 +253,9 @@ describe('Public Resumes Integration', () => {
 
       expect(response.status).toBe(201);
       const prisma = getPrisma();
-      const share = await prisma.resumeShare.findUnique({ where: { slug: response.body.slug } });
+      const share = await prisma.resumeShare.findUnique({
+        where: { slug: response.body.data.share.slug },
+      });
       expect(share).not.toBeNull();
       qrShareId = share!.id;
     });

--- a/test/infrastructure/integration/weekly-digest.integration.spec.ts
+++ b/test/infrastructure/integration/weekly-digest.integration.spec.ts
@@ -25,6 +25,20 @@ describe('Weekly Digest Integration', () => {
     });
     resumeId = resume.id;
 
+    // The service filters to users who explicitly opted in with
+    // emailDelivery='WEEKLY' + emailEnabled. Seed that preference so the test
+    // user is actually eligible — otherwise the service correctly returns
+    // { usersEmailed: 0, usersSkipped: 0 }.
+    await prisma.notificationPreference.create({
+      data: {
+        userId,
+        type: 'APPLICATION_STALE',
+        enabled: true,
+        emailEnabled: true,
+        emailDelivery: 'WEEKLY',
+      },
+    });
+
     sentEmails = [];
     const stubEmail = {
       sendEmail: async (opts: { to: string; subject: string; text: string }) => {
@@ -46,6 +60,7 @@ describe('Weekly Digest Integration', () => {
     await prisma.resumeViewEvent.deleteMany({ where: { resumeId } });
     await prisma.resumeVersion.deleteMany({ where: { resumeId } });
     await prisma.resume.delete({ where: { id: resumeId } });
+    await prisma.notificationPreference.deleteMany({ where: { userId } });
     await prisma.user.delete({ where: { id: userId } });
     await closeApp();
   });

--- a/test/release/domain/changelog.spec.ts
+++ b/test/release/domain/changelog.spec.ts
@@ -39,6 +39,32 @@ describe('changelog', () => {
       expect(lines[1]).toContain('#2');
       expect(lines[2]).toContain('#3');
     });
+
+    it('filters PRs merged before baseDate', () => {
+      // Regression: gather-changelog-data ships every PR merged on main +
+      // homolog without a date filter. If formatPatchChangelog doesn't honor
+      // baseDate, every patch release regurgitates the entire repo history
+      // (the bug that produced the 100-entry changelog on profile-services
+      // PR #218 / v0.2.3).
+      const result = formatPatchChangelog(basePRs, '2024-01-10T23:00:00Z');
+      const lines = result.split('\n').filter((l) => l.startsWith('-'));
+
+      expect(lines.length).toBe(2);
+      expect(result).not.toContain('#1');
+      expect(result).toContain('#2');
+      expect(result).toContain('#3');
+    });
+
+    it('is inclusive of baseDate (strict >)', () => {
+      // baseDate is the last release tag's date. A PR merged at that exact
+      // instant was already included in the previous release, so the new
+      // changelog must start strictly after it.
+      const result = formatPatchChangelog(basePRs, '2024-01-11T10:00:00Z');
+      const lines = result.split('\n').filter((l) => l.startsWith('-'));
+
+      expect(lines.length).toBe(1);
+      expect(result).toContain('#3');
+    });
   });
 
   describe('formatMinorChangelog', () => {


### PR DESCRIPTION
## Root cause
PR #218 (chore(release): v0.2.3) opened with 100+ historical PRs in its changelog — literally every PR ever merged to main/homolog. The bug:

1. `gather-changelog-data.ts` fetches **every** merged PR on main + homolog (by design — hands the date window to the consumer).
2. Minor / major formatters correctly filter PRs by `baseDate` (last tag date).
3. **Patch formatter ignored `baseDate` entirely** — looped every PR and printed.

So for patch releases, the changelog always included the entire repo history. The single-digit file change shown in PR #218 is misleading: the *diff* is tiny, but the *PR body* (the actual changelog) is 100+ lines.

## Fix
- `formatPatchChangelog` accepts optional `baseDate`, filters `pr.mergedAt > baseDate` when provided. Matches minor/major behavior.
- `gen-changelog.ts` threads `input.baseDate` through.
- Strict `>` (not `>=`) so a PR merged at the exact previous tag time isn't double-counted.

## Test plan
- [x] Regression test: PRs before cutoff dropped, PRs after kept
- [x] Regression test: strict-greater-than (PR at exact cutoff excluded)
- [x] Existing patch tests keep passing (baseDate still optional)
- [ ] After merge + new release PR, verify changelog only lists PRs since v0.2.2

## Note on PR #218
Once this lands, the stale v0.2.3 release PR (#218) should be closed (or updated). The next patch push to homolog will open a fresh PR with the correct, tight changelog.